### PR TITLE
Report the correct filename in error messages when parse_config_file is called recursively to handle include_conf directives.

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -510,14 +510,14 @@ sub parse_config_file {
 	my @configs = ();
 	
 	# open the config file
-	my $config_file = shift() || $config_file;
+	my $current_config_file = shift() || $config_file;
 	my $CONFIG;
-	if($config_file =~ /^`(.*)`$/) {
+	if($current_config_file =~ /^`(.*)`$/) {
 	    open($CONFIG, "$1 |") 
 	        or bail("Couldn't execute \"$1\" to get config information\n");
 	} else {
-	    $CONFIG = IO::File->new($config_file)
-		or bail("Could not open config file \"$config_file\"\nAre you sure you have permission?");
+	    $CONFIG = IO::File->new($current_config_file)
+		or bail("Could not open config file \"$current_config_file\"\nAre you sure you have permission?");
         }
 	
 	# read it line by line
@@ -527,6 +527,11 @@ sub parse_config_file {
 		
 		# count line numbers
 		$file_line_num++;
+		
+		# Ensure the correct filename is reported in error messages.  Setting it on
+		# every iteration ensures it will be reset after recursive calls to this
+		# function.
+		$config_file = $current_config_file;
 		
 		# assume the line is formatted incorrectly
 		my $line_syntax_ok = 0;


### PR DESCRIPTION
Hi,

The original filename was being reported when parsing included config files.  This change reports the correct filename; the line numbers were already correct.

Thanks,
