### PR TITLE
Print rnspashot's PID when logging to syslog (instead of the logger's program PID)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ http://www.rsnapshot.org/
 
 VERSION 1.3.x
 ------------------------------------------------------------------------------
+- Print rnspashot's PID when logging to syslog, instead of the logger's PID.
 - make script uses pod2man instead of /usr/bin/pod2man
 - rsnapshot-diff: Fixed removed files reported as addition (+ mark)
 - check for SIGPIPE, mainly in case cron fails when trying to mail

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -2098,15 +2098,15 @@ sub syslog_msg {
 	if (defined($config_vars{'cmd_logger'})) {
 		# print out our call to syslog
 		if (defined($verbose) && ($verbose >= 4)) {
-			print_cmd("$config_vars{'cmd_logger'} -i -p $facility.$level -t rsnapshot $msg");
+			print_cmd("$config_vars{'cmd_logger'} -p $facility.$level -t rsnapshot[$$] $msg");
 		}
 		
 		# log to syslog
 		if (0 == $test) {
-			$result = system($config_vars{'cmd_logger'}, '-i', '-p', "$facility.$level", '-t', 'rsnapshot', $msg);
+			$result = system($config_vars{'cmd_logger'}, '-p', "$facility.$level", '-t', "rsnapshot[$$]", $msg);
 			if (0 != $result) {
 				print_warn("Could not log to syslog:", 2);
-				print_warn("$config_vars{'cmd_logger'} -i -p $facility.$level -t rsnapshot $msg", 2);
+				print_warn("$config_vars{'cmd_logger'} -p $facility.$level -t rsnapshot[$$] $msg", 2);
 			}
 		}
 	}


### PR DESCRIPTION
This is much more useful because it allow to relate log lines to rsnapshot instances when there are multiple concurrent ones. Previously each logged line had a different PID, even those generated by the same rsnapshot instance.

This is achieved by removing the "-i" option from the logger's call, and appending the program's pid to the syslog tag (-t option) directly. Coincidentally, this obsoletes commit 0a056977d736df3adcc16e99a50dd06efbdb7a0e (which removed the "-i" option when the busybox logger was detected), so this commit is reverted too.
