### PR TITLE
Ability to wait for other instances to finish

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@ http://www.rsnapshot.org/
 
 VERSION 1.3.x
 ------------------------------------------------------------------------------
+- Allow rsnapshot to wait for the lockfile to be freed by another instance
+  instead of aborting.
 - make script uses pod2man instead of /usr/bin/pod2man
 - rsnapshot-diff: Fixed removed files reported as addition (+ mark)
 - check for SIGPIPE, mainly in case cron fails when trying to mail

--- a/rsnapshot.conf.default.in
+++ b/rsnapshot.conf.default.in
@@ -118,6 +118,12 @@ loglevel	3
 #
 lockfile	/var/run/rsnapshot.pid
 
+# Time (in minutes) to wait for the lockfile to be freed. If it is set
+# to 0 (the default), rsnapshot will exit immediately if there is
+# another instance running.
+#
+#lockfile_wait   0
+
 # Default rsync args. All rsync commands have at least these options set.
 #
 #rsync_short_args	-a


### PR DESCRIPTION
Introduces the ability to wait for other instances to finish their
execution, instead of instantly aborting in this condition. This
feature is implemented by specifying a maximum number of minutes
to wait for the lockfile to be freed.

When set to 0 (default), the previous behavior is unchanged.
