### PR TITLE
added missing =back.

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6609,6 +6609,8 @@ additional disk space will be taken up.
 
 =back
 
+=back
+
 Remember that tabs must separate all elements, and that
 there must be a trailing slash on the end of every directory.
 


### PR DESCRIPTION
newer pod2man (Pod::Man under the hood) requires =over and =back be matched.
