### PR TITLE
Fix --rsh commandline option

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3412,7 +3412,7 @@ sub rsync_backup_point {
 		
 		# if we have any args for SSH, add them
 		if ( defined($ssh_args) ) {
-			push( @rsync_long_args_stack, "--rsh=\"$config_vars{'cmd_ssh'} $ssh_args\"" );
+			push( @rsync_long_args_stack, "--rsh=$config_vars{'cmd_ssh'} $ssh_args" );
 			
 		# no arguments is the default
 		} else {


### PR DESCRIPTION
The --rsh=... argument to rsync was erroneously quoted when added to the
@rsync_long_args_stack with options set.

Test-Information:

Unit tests pass.
Tested and verified on Debian 7.0