### PR TITLE
Fix an issue where the postexec cmd script cannot unmount the USB backup...

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3958,7 +3958,16 @@ sub exec_cmd {
 	
 	print_cmd($cmd);
 	if (0 == $test) {
+		my $pre_systemcall_cwd = cwd();
+
+		# run $cmd from $HOME, allows unmounting of the snapshot root by
+		# cmd_postexec config option (se Debian Bug #660372)
+		chdir();
 		$return = system($cmd);
+
+		# return to the directory we were in before executing $cmd
+		chdir($pre_systemcall_cwd);
+
 		if (!defined($return)) {
 			print_err("Warning! exec_cmd(\"$cmd\") returned undef", 2);
 		}


### PR DESCRIPTION
Fix an issue where the postexec cmd script cannot unmount the USB backup drive because rsnapshot's current directory is the backup drive root.

Stolen directly from here:
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=660372
http://bugs.debian.org/cgi-bin/bugreport.cgi?msg=10;filename=rsnapshot_unmount-on-cmd-postexec.patch;att=1;bug=660372

I tested and it works.

Another solution is to allow the user to specify a working directory for the post exec script.