### PR TITLE
Add rsnapshot_mount_wrapper utility script

### DIFF
--- a/utils/README
+++ b/utils/README
@@ -77,3 +77,7 @@ sign_packages.sh
 ------------------------------------------------------------------------------
     The shell script used to automate package signing for releases.
 
+rsnapshot_mount_wrapper
+------------------------------------------------------------------------------
+    A wrapper script that mounts the configured rsnapshot_root, runs
+    rsnapshot, and then umounts the rsnapshot_root again, for safety reasons.

--- a/utils/rsnapshot_mount_wrapper
+++ b/utils/rsnapshot_mount_wrapper
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+##############################################################################
+# rsnapshot_mount_wrapper
+# by Pieter Hollants <suserpms@hollants.com>
+#
+# Wrapper script for rsnapshot that mounts <snapshot_root> before running
+# rsnapshot and umounts it again afterwards. This way your snapshot_root
+# stays umounted most of the time, thereby reducing the risk of accidentally
+# causing damage to it.
+##############################################################################
+
+# What's your name, son?
+ME=`basename $0`
+
+# Make sure the configuration file is readable
+if [ ! -r /etc/rsnapshot.conf ] ; then
+	logger -s -t ${ME} "Could not read /etc/rsnapshot.conf, check file permissions!"
+	exit 1
+fi
+
+# Get snapshot_root from rsnapshot configuration file
+ROOT=`grep ^snapshot_root /etc/rsnapshot.conf | sed 's/^.*\t//'`
+
+# Check if snapshot_root volume is mounted
+MOUNTED=0
+if [ ! `cat /proc/mounts | cut -d' ' -f2 | grep ${ROOT}` ] ; then
+	logger -s -t ${ME} "Mounting snapshot_root ${ROOT}..."
+
+	# Try to mount snapshot_root volume (requires a /etc/fstab entry)
+	mount ${ROOT}
+	if [ ! `cat /proc/mounts | cut -d' ' -f2 | grep ${ROOT}` ] ; then
+		logger -s -t ${ME} "Could not mount snapshot_root ${ROOT}!"
+		logger -s -t ${ME} "Device may not be connected or /etc/fstab entry is missing."
+		exit 1
+	fi
+
+	# Record that we mounted the volume ourselves, and thus may unmount it later
+	MOUNTED=1
+else
+	logger -s -t ${ME} "snapshot_root ${ROOT} already mounted."
+fi
+
+# Now call rsnapshot
+rsnapshot $@
+
+# Now unmount snapshot_root volume again for safety purposes
+if [ ${MOUNTED} -eq 1 ] ; then
+	logger -s -t ${ME} "Unmounting snapshot_root ${ROOT}..."
+	umount ${ROOT}
+fi

--- a/utils/rsnapshot_mount_wrapper.1
+++ b/utils/rsnapshot_mount_wrapper.1
@@ -1,0 +1,28 @@
+.TH rsnapshot_mount_wrapper 1 "08 Mar 2014" "" "rsnapshot mount wrapper"
+.\" -----------------------------------------------------------------
+.SH "NAME"
+.\" -----------------------------------------------------------------
+rsnapshot_mount_wrapper \- Mount wrapper for rsnapshot
+.\" -----------------------------------------------------------------
+.SH "SYNOPSIS"
+.\" -----------------------------------------------------------------
+.SY rsnapshot_mount_wrapper
+.OP options...
+.YS
+.\" -----------------------------------------------------------------
+.SH "DESCRIPTION"
+.\" -----------------------------------------------------------------
+\fBrsnapshot_mount_wrapper\fR is a wrapper script that is called instead of \fBrsnapshot\fR itself, taking all of its command line arguments. It will mount the 
+configured \fIsnapshot_root\fR, call \fBrsnapshot\fR, passing on any options it was passed itself, and umount the \fIrsnapshot_root\fR after the \fBrsnapshot\fR run..
+
+The idea is that you do not want your backup filesystem permanently mounted, in order to reduce the potential risk of damage. For example, a misguided script that walks 
+from \fI/\fR downwards removing files would also walk down the mounted backup filesystem, causing even greater damage. With \fBrsnapshot_mount_wrapper\fR, the time 
+window for such potential damage is reduced to the time the backup actually takes.
+.\" -----------------------------------------------------------------
+.SH "SEE ALSO"
+.\" -----------------------------------------------------------------
+\fBrsnapshot (1)\fR
+.\" -----------------------------------------------------------------
+.SH AUTHOR
+.\" -----------------------------------------------------------------
+Pieter Hollants <pieter@hollants.com>


### PR DESCRIPTION
rsnapshot_mount_wrapper mounts the configured snapshot_root just before
rsnapshot is run and umounts it afterwards, thereby reducing the potential
risk of damage to the backup filesystem to the time period rsnapshot is
actually running.
