### PR TITLE
Fix ssh_args implementation

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3412,8 +3412,8 @@ sub rsync_backup_point {
 		
 		# if we have any args for SSH, add them
 		if ( defined($ssh_args) ) {
-			push( @rsync_long_args_stack, "--rsh=\"$config_vars{'cmd_ssh'} $ssh_args\"" );
-			
+			push( @rsync_long_args_stack, "--rsh=$config_vars{'cmd_ssh'} $ssh_args" );
+
 		# no arguments is the default
 		} else {
 			push( @rsync_long_args_stack, "--rsh=$config_vars{'cmd_ssh'}" );


### PR DESCRIPTION
Previously, quotation marks were placed around the --rsh argument. While
this is necessary on the command-line to prevent the shell from
tokenizing the ssh_args, it is not necessary for perl exec from array
form and indeed, breaks rsync's tokenizing of the arguements.

This was discovered in http://sourceforge.net/p/rsnapshot/mailman/rsnapshot-discuss/thread/CAFyR6OntWmuxJ1XsUhzHuP4XFE0xMaUz8vNXHgqDgNWK4DG8ZA@mail.gmail.com/