### PR TITLE
Add filetest access pragma

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -45,6 +45,7 @@ use File::stat;			# stat(), lstat()
 use POSIX qw(locale_h);	# setlocale()
 use Fcntl;				# sysopen()
 use IO::File;			# recursive open in parse_config_file
+use filetest 'access';	# use access() call instead of stat() for file tests
 
 ########################################
 ###           CPAN MODULES           ###


### PR DESCRIPTION
On systems that use alternate file access schemes, like ACL's, stat()
may lie when checking file permissions. By using the access pragma,
access() is used instead for filetests, yielding correct results in
exchange for a slightly slower runtime.

This might be better off as a configuration option. I am not sure.