### PR TITLE
Use cwd() not $ENV{PWD}

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3496,7 +3496,7 @@ sub rsync_backup_point {
         
         # rewrite src to point to mount path
         # - to avoid including the mountpath in the snapshot, change the working directory and use a relative source
-        $linux_lvm_oldpwd = $ENV{PWD};
+        $linux_lvm_oldpwd = cwd();
         print_cmd("chdir($config_vars{'linux_lvm_mountpath'})");
         if (0 == $test) {
             $result = chdir($config_vars{'linux_lvm_mountpath'});


### PR DESCRIPTION
One liner to get rid of warn output shown below, which occurs because $ENV{PWD} is not set. $ENV{PWD} appears to be erroneous in any case, as it does not update with chdir() which has been called earlier at this point.

    sudo rsnapshot -c rsnapshot.conf sync
    Use of uninitialized value $linux_lvm_oldpwd in concatenation (.) or string at /usr/bin/rsnapshot line   3720.
    Use of uninitialized value $linux_lvm_oldpwd in chdir at /usr/bin/rsnapshot line 3722.
    Use of chdir('') or chdir(undef) as chdir() is deprecated at /usr/bin/rsnapshot line 3722.
    Logical volume "backups-rsnapshot" successfully removed

Test pass. Note this is a recommit of an older commit I did to master.