### PR TITLE
Fix use of ssh_args.

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3450,7 +3450,7 @@ sub rsync_backup_point {
 		
 		# if we have any args for SSH, add them
 		if ( defined($ssh_args) ) {
-			push( @rsync_long_args_stack, "--rsh=\"$config_vars{'cmd_ssh'} $ssh_args\"" );
+			push( @rsync_long_args_stack, "--rsh=$config_vars{'cmd_ssh'} $ssh_args" );
 			
 		# no arguments is the default
 		} else {


### PR DESCRIPTION
system() is called with an array instead of a string, so the shell isn't used for this system() call.  Since the shell isn't used, it's incorrect to quote arguments.  Without this patch, ssh_args can't actually be used.  rsync will try to execute "ssh ssh_args" as argv[0] which always fails.
