### PR TITLE
grab output from rsync and put to log

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ http://www.rsnapshot.org/
 
 VERSION 1.3.x
 ------------------------------------------------------------------------------
+- Capture output from rsync and print/log if level is >=4
 - Print rnspashot's PID when logging to syslog, instead of the logger's PID.
 - make script uses pod2man instead of /usr/bin/pod2man
 - rsnapshot-diff: Fixed removed files reported as addition (+ mark)

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3648,7 +3648,7 @@ sub rsync_backup_point {
 	$result = 1;
 	if (0 == $test) {
 		while ($tryCount < $rsync_numtries && $result !=0) {
-			my $pid = open(RSYNC, "@cmd_stack 2>&1 |")
+			my $pid = open(RSYNC, "|-", (@cmd_stack, "2>&1 |"))
 				or die "Couldn't fork rsync: $!\n";
 			while(<RSYNC>){
 				print_msg($_, 4);


### PR DESCRIPTION
This snippet allows you to log the entries of rsync and pipe them into the rsnapshot logfile.