### PR TITLE
fix for #48 -- if($use_lazy_deletes): remove lockfile in any case

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -2964,25 +2964,28 @@ sub handle_interval {
 	}
 	
 	# if use_lazy_delete is on, delete the _delete.$$ directory
-	# we just check for the directory, it will have been created or not depending on the value of use_lazy_delete
-	if ( -d "$config_vars{'snapshot_root'}/_delete.$$" ) {
-		# this is the last thing to do here, and it can take quite a while.
+	if ($use_lazy_deletes) {
+		# Besides the _delete.$$ directory, the lockfile has to be removed as well.
+		# The reason is that the last task to do in this subroutine is to delete the _delete.$$ directory, and it can take quite a while.
 		# we remove the lockfile here since this delete shouldn't block other rsnapshot jobs from running
 		remove_lockfile();
 		
-		# start the delete
-		display_rm_rf("$config_vars{'snapshot_root'}/_delete.$$");
-		if (0 == $test) {
-			my $result = rm_rf( "$config_vars{'snapshot_root'}/_delete.$$" );
-			if (0 == $result) {
-				bail("Error! rm_rf(\"$config_vars{'snapshot_root'}/_delete.$$\")\n");
+		# Check for the directory. It might not exist, e.g. in case of the 'sync' command.
+		if ( -d "$config_vars{'snapshot_root'}/_delete.$$" ) {
+			# start the delete
+			display_rm_rf("$config_vars{'snapshot_root'}/_delete.$$");
+			if (0 == $test) {
+				my $result = rm_rf( "$config_vars{'snapshot_root'}/_delete.$$" );
+				if (0 == $result) {
+					bail("Error! rm_rf(\"$config_vars{'snapshot_root'}/_delete.$$\")\n");
+				}
 			}
+		} else {
+			# only spit this out if lazy deletes are turned on.
+			# Still need to suppress this if they're turned on but we've
+			# not done enough backups to yet need to delete anything
+			print_msg("No directory to delete: $config_vars{'snapshot_root'}/_delete.$$", 5);
 		}
-	} elsif($use_lazy_deletes) {
-	        # only spit this out if lazy deletes are turned on.
-		# Still need to suppress this if they're turned on but we've
-		# not done enough backups to yet need to delete anything
-		print_msg("No directory to delete: $config_vars{'snapshot_root'}/_delete.$$", 5);
 	}
 }
 


### PR DESCRIPTION
About the commit: I don't really understand the comment in the `else` block (see below), but I think it needs to be updated.

```perl
		} else {
			# only spit this out if lazy deletes are turned on.
			# Still need to suppress this if they're turned on but we've
			# not done enough backups to yet need to delete anything
			print_msg("No directory to delete: $config_vars{'snapshot_root'}/_delete.$$", 5);
		}
```