### PR TITLE
Log what pid was locked.

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -2322,7 +2322,7 @@ sub remove_lockfile {
 		  chomp(my $locked_pid = <LOCKFILE>);
 		  close(LOCKFILE);
 		  if($locked_pid != $$) {
-		    print_warn("About to remove lockfile $lockfile which belongs to a different process (this is OK if it's a stale lock)");
+		    print_warn("About to remove lockfile $lockfile which belongs to a different process: $locked_pid (this is OK if it's a stale lock)");
 		  }
 		} else {
 		  print_err ("Could not read lockfile $lockfile: $!", 0);


### PR DESCRIPTION
Logging what pid was locked is useful for debugging when bad things
happen to rsnapshot lock files.