### PR TITLE
add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+os:
+  - linux
+  - osx
+language: perl
+perl:
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+install:
+  - "./autogen.sh"
+  - "./configure"
+script:
+  - make
+  - make test
+before_deploy:
+  - make tar
+deploy:
+  provider: releases
+  api_key:
+    secure: <need to generate and encrypt the key>
+  file: rsnapshot-${TRAVIS_TAG}.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true
+notifications:
+  email:
+    # maybe we have to add rsnapshot-maintainers@lists.sourceforge.net
+    # this will depend on activity and notification-settings
+    recipients:
+      - benedikt@heine.rocks
+    on_success: change
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: <need to generate and encrypt the key>
+    secure: vlYgJ2PWqfM1YA9Rw/qpJntaRl276uq8BcL7raDMNDySqO7QUg2TIilxWRxiiWLGjHUabAdsn8fsNEYmHfCLKywJdqzU90SS9KDWmSuVgzJfLBIPYlgfVMjEa0QQRZgJ7k1Oe2jsmH9lJuZw9jW/xG2C4eQRqAQ64m+UWwcDHqw=
   file: rsnapshot-${TRAVIS_TAG}.tar.gz
   skip_cleanup: true
   on:

--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,3 @@
-rsnapshot 1.3.1
-http://www.rsnapshot.org/
-
 rsnapshot is a filesystem snapshot utility. It uses rsync to take
 snapshots of local and remote filesystems for any number of machines,
 and then rotates the snapshots according to your rsnapshot.conf.

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 # rsnapshot version
-VERSION = 1.3.1.1
+VERSION = @VERSION@
 
 # Where RPM files are built on this system
 RPM_BASE_DIR = /usr/src/redhat
@@ -86,8 +86,8 @@ rsnapshot-$(VERSION).tar.gz: $(man_MANS) rpm-patch Makefile $(bin_SCRIPTS) $(sys
 	
 	@# core files
 	mkdir rsnapshot-$(VERSION)
-	cp -p rsnapshot-preamble.pl rsnapshot-program.pl rsnapshot-diff.pl rsnapshot.conf.default.in \
-		$(man_MANS) AUTHORS COPYING INSTALL README TODO NEWS ChangeLog \
+	cp -p rsnapshot-program.pl rsnapshot-diff.pl rsnapshot.conf.default.in \
+		$(man_MANS) AUTHORS COPYING INSTALL README NEWS ChangeLog \
 		rsnapshot-$(VERSION)/
 
 	@# documentation files
@@ -121,7 +121,7 @@ rsnapshot-$(VERSION).tar.gz: $(man_MANS) rpm-patch Makefile $(bin_SCRIPTS) $(sys
 	-find rsnapshot-$(VERSION)/ -depth -name CVS -exec rm -rf {} \;
 	
 	@# change ownership to root, and delete build dir
-	-chown -R root:root rsnapshot-$(VERSION)/
+	-fakeroot chown -R root:root rsnapshot-$(VERSION)/
 	tar czf rsnapshot-$(VERSION).tar.gz rsnapshot-$(VERSION)/
 	rm -rf rsnapshot-$(VERSION)/
 	@echo

--- a/README
+++ b/README
@@ -1,6 +1,3 @@
-rsnapshot 1.3.1
-http://www.rsnapshot.org/
-
 ------------------------------------------------------------------------------
 rsnapshot comes with ABSOLUTELY NO WARRANTY.  This is free software,
 and you are welcome to redistribute it under certain conditions.

--- a/autoclean.sh
+++ b/autoclean.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xu
+#!/bin/sh
 
 [ -f Makefile ] && make clean
 rm -rf autom4te.cache

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,3 @@
-#!/bin/sh -x
+#!/bin/sh
 
-aclocal
-autoconf
-automake --add-missing --copy
+autoreconf -i

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,8 @@
-AC_INIT(rsnapshot, 1.3.1.1, rsnapshot-discuss@lists.sourceforge.net)
+AC_INIT(rsnapshot, [m4_esyscmd_s([git describe --tags --always])], rsnapshot-discuss@lists.sourceforge.net)
 AM_INIT_AUTOMAKE
 AC_PROG_MAKE_SET
 AC_PROG_INSTALL
+AC_PROG_LIBTOOL
 AC_CONFIG_FILES(Makefile)
 
 dnl

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -61,7 +61,7 @@ my $have_lchown = 0;
 $| = 1;
 
 # version of rsnapshot
-my $VERSION = '1.3.1';
+my $VERSION = '@VERSION@';
 
 # command or interval to execute (first cmd line arg)
 my $cmd;


### PR DESCRIPTION
There had been multiple issues to fix also in
compilation/building-system to give travis the ability to build
properly. The progress is still missing, a key, that travis can
automatically deploy to github-releases.

You can see how it will look like at my spam-repository. There are just bogus commits/PRs/releases/tags made.
A bogus PR: https://github.com/bebehei/rsnapshot-clone/pull/1
Check out the releases-page, too!