### PR TITLE
bail on failing cmd preexec or cmd postexec

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -272,6 +272,12 @@ AC_CONFIG_FILES(t/support/etc/backup_exec_fail.conf:t/support/etc/backup_exec_fa
 AC_CONFIG_FILES(t/support/etc/link-dest_-t_when_only_one_snapshot.conf:t/support/etc/link-dest_-t_when_only_one_snapshot.conf.in)
 AC_CONFIG_FILES(t/support/etc/ssh_args.conf:t/support/etc/ssh_args.conf.in)
 
+AC_CONFIG_FILES(t/cmd-post_pre-exec/pre-false-post-false.conf:t/cmd-post_pre-exec/pre-false-post-false.conf.in)
+AC_CONFIG_FILES(t/cmd-post_pre-exec/pre-false-post-true.conf:t/cmd-post_pre-exec/pre-false-post-true.conf.in)
+AC_CONFIG_FILES(t/cmd-post_pre-exec/pre-true-post-false.conf:t/cmd-post_pre-exec/pre-true-post-false.conf.in)
+AC_CONFIG_FILES(t/cmd-post_pre-exec/pre-true-post-true.conf:t/cmd-post_pre-exec/pre-true-post-true.conf.in)
+
+
 dnl regression test scripts
 AC_CONFIG_FILES(t/configtest.t:t/configtest.t.in)
 AC_CONFIG_FILES(t/rsync.t:t/rsync.t.in)
@@ -282,6 +288,7 @@ AC_CONFIG_FILES(t/backup_exec.t:t/backup_exec.t.in)
 AC_CONFIG_FILES(t/backup_exec_fail.t:t/backup_exec_fail.t.in)
 AC_CONFIG_FILES(t/link-dest_-t_when_only_one_snapshot.t:t/link-dest_-t_when_only_one_snapshot.t.in)
 AC_CONFIG_FILES(t/ssh_args.t:t/ssh_args.t.in)
+AC_CONFIG_FILES(t/cmd-post_pre-exec.t:t/cmd-post_pre-exec.t.in)
 
 AC_OUTPUT
 

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6198,7 +6198,7 @@ B<cmd_preexec>
 
 Full path (plus any arguments) to preexec script (optional).
 This script will run immediately before each backup operation (but not any
-rotations).
+rotations). If the execution fails, rsnapshot will stop immediately.
 
 =back
 
@@ -6208,7 +6208,7 @@ B<cmd_postexec>
 
 Full path (plus any arguments) to postexec script (optional).
 This script will run immediately after each backup operation (but not any
-rotations).
+rotations). If the execution fails, rsnapshot will stop immediately.
 
 =back
 

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -4036,7 +4036,7 @@ sub exec_cmd_preexec {
 	}
 	
 	if (0 != $retval) {
-		print_warn("cmd_preexec \"$config_vars{'cmd_preexec'}\" returned $retval", 2);
+		bail("cmd_preexec \"$config_vars{'cmd_preexec'}\" returned $retval");
 	}
 	
 	return ($retval);
@@ -4057,7 +4057,7 @@ sub exec_cmd_postexec {
 	}
 	
 	if (0 != $retval) {
-		print_warn("cmd_postexec \"$config_vars{'cmd_postexec'}\" returned $retval", 2);
+		bail("cmd_postexec \"$config_vars{'cmd_postexec'}\" returned $retval");
 	}
 	
 	return ($retval);

--- a/t/cmd-post_pre-exec.t.in
+++ b/t/cmd-post_pre-exec.t.in
@@ -1,0 +1,24 @@
+#!@PERL@
+#
+#
+# Testing: Only pass test, if both cmd_preexec and cmd_postexec succeeds and the exit-code matches
+
+use strict;
+use Test::More tests => 4;
+
+# Ensure passing behavior
+system("@PERL@ ./rsnapshot -c t/cmd-post_pre-exec/pre-false-post-false.conf hourly");
+my $rc = $? >> 8;
+ok($rc != 0);
+
+system("@PERL@ ./rsnapshot -c t/cmd-post_pre-exec/pre-false-post-true.conf hourly");
+$rc = $? >> 8;
+ok($rc != 0);
+
+system("@PERL@ ./rsnapshot -c t/cmd-post_pre-exec/pre-true-post-false.conf hourly");
+$rc = $? >> 8;
+ok($rc != 0);
+
+system("@PERL@ ./rsnapshot -c t/cmd-post_pre-exec/pre-true-post-true.conf hourly");
+$rc = $? >> 8;
+ok($rc == 0);

--- a/t/cmd-post_pre-exec/pre-false-post-false.conf.in
+++ b/t/cmd-post_pre-exec/pre-false-post-false.conf.in
@@ -1,0 +1,11 @@
+config_version	1.2
+
+snapshot_root	@CWD@/t/support/snapshots/
+cmd_rsync		@RSYNC@
+
+interval		hourly	2
+
+cmd_preexec	/bin/false
+cmd_postexec	/bin/false
+
+backup	@CWD@/t/support/files		cmd_pre_postexectest/

--- a/t/cmd-post_pre-exec/pre-false-post-true.conf.in
+++ b/t/cmd-post_pre-exec/pre-false-post-true.conf.in
@@ -1,0 +1,11 @@
+config_version	1.2
+
+snapshot_root	@CWD@/t/support/snapshots/
+cmd_rsync		@RSYNC@
+
+interval		hourly	2
+
+cmd_preexec	/bin/false
+cmd_postexec	/bin/true
+
+backup	@CWD@/t/support/files		cmd_pre_postexectest/

--- a/t/cmd-post_pre-exec/pre-true-post-false.conf.in
+++ b/t/cmd-post_pre-exec/pre-true-post-false.conf.in
@@ -1,0 +1,11 @@
+config_version	1.2
+
+snapshot_root	@CWD@/t/support/snapshots/
+cmd_rsync		@RSYNC@
+
+interval		hourly	2
+
+cmd_preexec	/bin/true
+cmd_postexec	/bin/false
+
+backup	@CWD@/t/support/files		cmd_pre_postexectest/

--- a/t/cmd-post_pre-exec/pre-true-post-true.conf.in
+++ b/t/cmd-post_pre-exec/pre-true-post-true.conf.in
@@ -1,0 +1,11 @@
+config_version	1.2
+
+snapshot_root	@CWD@/t/support/snapshots/
+cmd_rsync		@RSYNC@
+
+interval		hourly	2
+
+cmd_preexec	/bin/true
+cmd_postexec	/bin/true
+
+backup	@CWD@/t/support/files		cmd_pre_postexectest/


### PR DESCRIPTION
As requested on rsnapshot/sourceforge-issues#47.

For me it makes sense, when cmd_preexec fails, that the backup should not get executed.

Comment on the changeset from the sourceforge-issue: I don't want to add a new configuration-option to this. If users really want to have the backup executed although cmd_preexec fails, they have to `exit(0)` in their script.

@rsnapshot/maintainers What do you think?