### PR TITLE
refine the error-message, when sourcing include_conf script fails

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -580,7 +580,11 @@ sub parse_config_file {
 				$line_syntax_ok = 1;
 				parse_config_file($value);
 			} else {
-				config_err($file_line_num, "$line - can't find or read file '$value'");
+				if(defined($1)){
+					config_err($file_line_num, "$line - not a valid script: '$1'");
+				} else {
+					config_err($file_line_num, "$line - can't find or read file '$value'");
+				}
 				next;
 			}
 		}


### PR DESCRIPTION
according to rsnapshot/sourceforge-issues#48 if you have in your config-file

    include_conf `./this_file_gives_out_valid_configlines_on_execution.sh`

You will suffer, that it says:

    ERROR: include_conf `./test.sh` - can't find or read file '`./this_file_gives_out_valid_configlines_on_execution.sh`' 

But in fact, it fails, cause `is_valid_script("./this_file_gives_out_valid_configlines_on_execution.sh")` returns false.

Now the error-message differs between a config-file and a config-script.