### PR TITLE
add warning, when setting multiple times verbosity

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,11 @@ rsnapshot changelog
 http://www.rsnapshot.org/
 ------------------------------------------------------------------------------
 
+current master
+------------------------------------------------------------------------------
+- Display warning, when the verbosity is set multiple times (e.g. on
+  command-line and logfile at the same time)
+
 VERSION 1.4.0
 ------------------------------------------------------------------------------
 - Tidy the code with perltidy

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -1442,6 +1442,8 @@ sub parse_config_file {
 			if (1 == is_valid_loglevel($value)) {
 				if (!defined($verbose)) {
 					$verbose = $value;
+				} elsif($verbose < $value ) {
+					print_warn("The verbosity-level is \"$verbose\" despite subsequent declaration at line $file_line_num.");
 				}
 
 				$line_syntax_ok = 1;


### PR DESCRIPTION
adds a warning, when the verbosity is previously set to a higher
level in a subsequent declaration. This is useful, when you accidentally
set the -v option and define a higher verbosity in your config-file.

closes #47 