### PR TITLE
remove libtool from buildsystem

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,8 +51,7 @@ rsnapshot-$(VERSION).tar.gz: $(man_MANS) Makefile $(bin_SCRIPTS) $(sysconf_DATA)
 
 	@# autoconf files
 	cp -apr configure.ac Makefile.am \
-		aclocal.m4 autom4te.cache config.guess config.sub configure \
-		install-sh ltmain.sh Makefile.in missing \
+		aclocal.m4 autom4te.cache configure install-sh Makefile.in missing \
 		rsnapshot-$(VERSION)/
 
 	@# documentation files

--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,6 @@
 AC_INIT([rsnapshot],[m4_esyscmd_s([git describe --tags --always --dirty])],[rsnapshot-discuss@lists.sourceforge.net])
 AM_INIT_AUTOMAKE([foreign])
 AC_PROG_MAKE_SET
-AC_PROG_INSTALL
-LT_INIT
 AC_CONFIG_FILES(Makefile)
 
 dnl


### PR DESCRIPTION
Under OpenSuse, rsnapshot won't build, cause libtool is not needed. and rm of libtoolT fails during build.
