### PR TITLE
Rotate only if there will be a new <interval>.0 folder

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3362,6 +3362,18 @@ sub rotate_lowest_snapshots {
 
 	my $result;
 
+	# cancel if sync_first is enabled but .sync directory not existent
+	if (($config_vars{'sync_first'}) && (!-d "$config_vars{'snapshot_root'}/.sync/")) {
+		print_err(
+			"sync_first is enabled, but there is no .sync directory! Run rsnapshot with the ´sync´ command first. Refusing to rotate this level ($interval)",
+			1
+		);
+		syslog_err(
+			"sync_first is enabled, but there is no .sync directory! Run rsnapshot with the ´sync´ command first. Refusing to rotate this level ($interval)"
+		);
+		bail();
+	}
+
 	# remove oldest directory
 	if ((-d "$config_vars{'snapshot_root'}/$interval.$interval_max") && ($interval_max > 0)) {
 
@@ -4665,6 +4677,19 @@ sub rotate_higher_interval {
 	my $interval_max      = $$id_ref{'interval_max'};
 	my $prev_interval     = $$id_ref{'prev_interval'};
 	my $prev_interval_max = $$id_ref{'prev_interval_max'};
+
+	# here we check, if $prev_interval.$prev_interval_max exists and only do the rotation, if from that level can be pulled...
+	# otherwise bail. Maybe there should be an option for such new behaviour, too?
+	if (!-d "$config_vars{'snapshot_root'}/$prev_interval.$prev_interval_max") {
+		print_err(
+			"Did not find previous interval max ($config_vars{'snapshot_root'}/$prev_interval.$prev_interval_max), refusing to rotate this level ($interval)",
+			1
+		);
+		syslog_err(
+			"Did not find previous interval max ($config_vars{'snapshot_root'}/$prev_interval.$prev_interval_max), refusing to rotate this level ($interval)"
+		);
+		bail();
+	}
 
 	# ROTATE DIRECTORIES
 	#

--- a/t/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf.in
+++ b/t/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf.in
@@ -1,0 +1,6 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+interval		hourly	3
+interval		weekly	6
+backup			@TEMP@	localhost/

--- a/t/rotate_only_when_0_avail/rotate_only_when_0_avail.t.in
+++ b/t/rotate_only_when_0_avail/rotate_only_when_0_avail.t.in
@@ -1,0 +1,23 @@
+#!@PERL@
+
+use strict;
+use Test::More tests => 10;
+use SysWrap;
+
+remove_snapshot_root();
+ok(0 != rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));
+
+remove_snapshot_root();
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 != rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));
+
+remove_snapshot_root();
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 != rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));
+
+remove_snapshot_root();
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));

--- a/t/rotate_only_when_0_avail/rotate_only_when_0_avail.t.in
+++ b/t/rotate_only_when_0_avail/rotate_only_when_0_avail.t.in
@@ -1,7 +1,7 @@
 #!@PERL@
 
 use strict;
-use Test::More tests => 10;
+use Test::More tests => 11;
 use SysWrap;
 
 remove_snapshot_root();
@@ -21,3 +21,4 @@ ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_av
 ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
 ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
 ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));
+ok(0 != rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly")); 


### PR DESCRIPTION
With this bugfix, gaps like a missing <interval>.0 folder will be prevented.
See bug #18.

replace #34 