### PR TITLE
rsync >= 3.1.0 stats and bytes changes for utils/rsnapreport.pl

### DIFF
--- a/utils/rsnapreport.pl
+++ b/utils/rsnapreport.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 # this script prints a pretty report from rsnapshot output
 # in the rsnapshot.conf you must set
-# verbose >= 3
+# verbose >= 4
 # and add --stats to rsync_long_args
 # then setup crontab 'rsnapshot daily 2>&1 | rsnapreport.pl | mail -s"SUBJECT" backupadm@adm.com
 # don't forget the 2>&1 or your errors will be lost to stderr
@@ -90,17 +90,23 @@ while (my $line = nextLine(\@rsnapout)){
 			}
 			# stat record
 			if($line =~ /^total size is\s+\d+/){ last; } # this ends the rsync stats record
-			elsif($line =~ /Number of files:\s+(\d+)/){
+			# Number of files: 1,325 (reg: 387, dir: 139, link: 799)
+			elsif($line =~ /Number of files:\s+(.+) \(/){
 				$bkdata{$source}{'files'}=$1;
+				$bkdata{$source}{'files'}=~ s/,//g;
 			}
-			elsif($line =~ /Number of files transferred:\s+(\d+)/){
-				$bkdata{$source}{'files_tran'}=$1;
+			# Number of regular files transferred: 1
+			elsif($line =~ /Number of (regular )?files transferred:\s+(\d+)/){
+				$bkdata{$source}{'files_tran'}=$2;
 			}
-			elsif($line =~ /Total file size:\s+(\d+)/){
+			# Total file size: 1,865,857 bytes
+			elsif($line =~ /Total file size:\s+(.+) bytes/){
 				$bkdata{$source}{'file_size'}=$1;
+				$bkdata{$source}{'file_size'}=~ s/,//g;
 			}
-			elsif($line =~ /Total transferred file size:\s+(\d+)/){
+			elsif($line =~ /Total transferred file size:\s+(.+) bytes/){
 				$bkdata{$source}{'file_tran_size'}=$1;
+				$bkdata{$source}{'file_tran_size'}=~ s/,//g;
 			}
 			elsif($line =~ /File list generation time:\s+(.+)/){
 				$bkdata{$source}{'file_list_gen_time'}=$1;


### PR DESCRIPTION
- Minimum verbosity to have rsync output is 4
- Details on "Number of files", change regexp
- Number of (regular )?files transferred
- Bytes are now comma separated
- Provide example lines to handle future rsync changes