### PR TITLE
Grab rsync's exit code

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ current master
 - Display warning, when the verbosity is set multiple times (e.g. on
   command-line and logfile at the same time)
 - Changed maintainership in all files.
+- Capture rsync's output right (Github issue 102)
 
 VERSION 1.4.0
 ------------------------------------------------------------------------------

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3920,7 +3920,7 @@ sub rsync_backup_point {
 			}
 
 			waitpid($pid, 0);
-			$result = $?;
+			$result = $? >> 8;
 			$tryCount += 1;
 		}
 

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3919,6 +3919,7 @@ sub rsync_backup_point {
 				print_msg($_, 4);
 			}
 
+			waitpid($pid, 0);
 			$result = $?;
 			$tryCount += 1;
 		}

--- a/t/rsync-exitcode/conf/rsync-exitcode-bad.conf.in
+++ b/t/rsync-exitcode/conf/rsync-exitcode-bad.conf.in
@@ -1,0 +1,5 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		false
+interval		hourly	6
+backup			@TEST@/support/files/a/	localhost/

--- a/t/rsync-exitcode/conf/rsync-exitcode-good.conf.in
+++ b/t/rsync-exitcode/conf/rsync-exitcode-good.conf.in
@@ -1,0 +1,5 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+interval		hourly	6
+backup			@TEST@/support/files/a/	localhost/

--- a/t/rsync-exitcode/rsync-exitcode.t.in
+++ b/t/rsync-exitcode/rsync-exitcode.t.in
@@ -1,0 +1,13 @@
+#!@PERL@
+
+use strict;
+use Test::More tests => 2;
+use SysWrap;
+
+mkdir("@TEST@/support/files/a") unless -d "@TEST@/support/files/a";
+execute("cp @TEMP@/a/1 @TEMP@/a/2 @TEST@/support/files/a/");
+
+ok(0 != rsnapshot("-c @TEST@/rsync-exitcode/conf/rsync-exitcode-bad.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/rsync-exitcode/conf/rsync-exitcode-good.conf hourly"));
+
+execute("rm -f @TEST@/support/files/a/1 @TEST@support/files/a/2");


### PR DESCRIPTION
This may be the solution for #102 

I have to test it and get more knowledge about child-processes.

I don't know how it will behave, when rsync closes STDERR and STDOUT and exits before we call waitpid.