### PR TITLE
Non-LVM backup source breaks after LVM backup source

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3952,13 +3952,13 @@ sub rsync_backup_point {
 	# delte the traps manually
 	# umount LVM Snapshot if it is mounted
 	if (1 == $traps{"linux_lvm_mountpoint"}) {
-		undef $traps{"linux_lvm_mountpoint"};
+		$traps{"linux_lvm_mountpoint"} = 0;
 		linux_lvm_unmount();
 	}
 
 	# destroy snapshot created by rsnapshot
 	if (0 ne $traps{"linux_lvm_snapshot"}) {
-		undef $traps{"linux_lvm_snapshot"};
+		$traps{"linux_lvm_snapshot"} = 0;
 		linux_lvm_snapshot_del(linux_lvm_parseurl($lvm_src));
 	}
 }


### PR DESCRIPTION
A Debian user reported that if /etc/rsnapshot.conf has an LVM backup source followed by non-LVM backup sources, rsnapshot encounter an error. Instead of undefine the trap variable, the patch reset it to 0.

Source: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=794046