### PR TITLE
Don't shift rsync return code again

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3926,13 +3926,9 @@ sub rsync_backup_point {
 
 		# now we see if rsync ran successfully, and what to do about it
 		if ($result != 0) {
-
-			# bitmask return value
-			my $retval = get_retval($result);
-
 			# print warnings, and set this backup point to rollback if we're using --link-dest
 			#
-			handle_rsync_error($retval, $bp_ref);
+			handle_rsync_error($result, $bp_ref);
 		}
 		else {
 			print_msg("rsync succeeded", 5);


### PR DESCRIPTION
since e2f14aa1469a39d1ba2590ff011fb6563cfd6d7c is doing exactly that already.
Will fix rsync error handling, as well as logging strange error codes like:
ERROR: /usr/bin/rsync returned 0.08984375 while processing root@host:/
ERROR: /usr/bin/rsync returned 0.99609375 while processing root@host:/
