### PR TITLE
Implement cmd_mkbackupdir option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,6 +143,39 @@ AC_SUBST(CMD_RM, "cmd_rm		$RM")
 
 
 dnl
+dnl MKBACKUPDIR CHECK (optional program)
+dnl
+dnl if the user specified a path, try that first
+AC_ARG_WITH(mkbackupdir,
+	[  --with-mkbackupdir=PATH Specify the path to mkbackupdir ],
+	[
+		if test "x$withval" != "xno"; then
+			if test -x "$withval"; then
+				MKBACKUPDIR=$withval
+			else
+				AC_MSG_ERROR(mkbackupdir not found)
+			fi
+		else
+			RM=no
+		fi
+	]
+)
+dnl if the user didn't specify a path, hunt for it
+if test "$MKBACKUPDIR" != "no"; then
+	AC_PATH_PROG(MKBACKUPDIR, mkbackupdir, no)
+fi
+dnl save the program for testing
+AC_SUBST(TEST_RM, "$MKBACKUPDIR")
+dnl if we couldn't find it, provide an example
+if test "$MKBACKUPDIR" = "no"; then
+	MKBACKUPDIR=/bin/mkdir
+fi
+dnl either way, set the cmd_mkbackupdir var
+AC_SUBST(CMD_MKBACKUPDIR, "cmd_mkbackupdir	$MKBACKUPDIR")
+
+
+
+dnl
 dnl SSH CHECK (optional program)
 dnl
 dnl if the user specified a path, try that first

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6768,6 +6768,8 @@ files over (assuming there are any).
 
 B<cmd_rm>             Full path to rm (optional)
 
+B<cmd_mkbackupdir>    Full path to mkdir or equivalent (optional)
+
 B<cmd_logger>         Full path to logger (optional, for syslog support)
 
 B<cmd_du>             Full path to du (optional, for disk usage reports)

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -786,6 +786,20 @@ sub parse_config_file {
 			}
 		}
 
+		# CHECK FOR mkbackupdir (optional)
+		if ($var eq 'cmd_mkbackupdir') {
+			$value =~ s/\s+$//;
+			if ((-f "$value") && (-x "$value") && (1 == is_real_local_abs_path($value))) {
+				$config_vars{'cmd_mkbackupdir'} = $value;
+				$line_syntax_ok = 1;
+				next;
+			}
+			else {
+				config_err($file_line_num, "$line - $value is not executable");
+				next;
+			}
+		}
+
 		# CHECK FOR LOGGER (syslog program) (optional)
 		if ($var eq 'cmd_logger') {
 			$value =~ s/\s+$//;
@@ -4521,12 +4535,25 @@ sub create_backup_point_dir {
 
 	# create the directory if it doesn't exist
 	if (!-e "$destpath") {
-		print_cmd("mkdir -m 0755 -p $destpath/");
+		if (defined($config_vars{'cmd_mkbackupdir'})) {
+			my $result;
+			my $status;
+			print_cmd("$config_vars{'cmd_mkbackupdir'} -m 0755 -p $destpath");
+			$result = system($config_vars{'cmd_mkbackupdir'}, "-m", "0755", "-p", "$destpath");
 
-		if (0 == $test) {
-			eval { mkpath("$destpath", 0, 0755); };
-			if ($@) {
-				bail("Could not mkpath(\"$destpath/\", 0, 0755);");
+			if ($result != 0) {
+				$status = get_retval($result);
+				bail("$config_vars{'cmd_mkbackupdir'} $destpath failed (result $result, exit status $status).");
+			}
+		}
+		else {
+			print_cmd("mkdir -m 0755 -p $destpath/");
+
+			if (0 == $test) {
+				eval { mkpath("$destpath", 0, 0755); };
+				if ($@) {
+					bail("Could not mkpath(\"$destpath/\", 0, 0755);");
+				}
 			}
 		}
 	}

--- a/rsnapshot.conf.default.in
+++ b/rsnapshot.conf.default.in
@@ -43,6 +43,10 @@ snapshot_root	/.snapshots/
 #
 @CMD_RM@
 
+# uncomment this to use a custom mkdir program to create a backup directory
+#
+#@CMD_MKBACKUPDIR@
+
 # rsync must be enabled for anything to work. This is the only command that
 # must be enabled.
 #


### PR DESCRIPTION
This implements the proposed cmd_mkbackupdir option from #20.

Previously, you'd have to create btrfs subvolumes for possible snapshot directories (.sync and lowest_interval.0) for all hosts manually before running rsnapshot for the first time.
Now, you can point cmd_mkbackupdir to an executable that creates the directory for you whenever its needed.

This allows us to take advantage of btrfs features:
- use cmd_cp to use btrfs subvolume snapshot instead of a slow cp operation -> instant cp
- use cmd_rm to use btrfs subvolume delete instead of slow rm -> instant removal of old backups
- use cmd_mkbackupdir to create subvolumes which are necessary for the two above

Overall, this reduces the backup time to the differential rsync operation, all additional IO operations are now instant.
Previously, my hourly backup rotation (+ deletion of old backups) took 17s for my server and 4m7s for my desktop backup. Both of them are now done in one second.
The more files you have in your backup, the more time you will save.

Note: At the beginning, I used read-only snapshots, but this breaks when the .sync directory is missing and gets recreated from the latest snapshot. Then, the .sync directory would have been read-only and rsync fails.

I am using this with the following config options:
```
cmd_cp				/usr/local/sbin/rsnapshot-cp-btrfs
cmd_rm				/usr/local/sbin/rsnapshot-rm-btrfs
cmd_mkbackupdir		/usr/local/sbin/rsnapshot-mkbackupdir-btrfs
```

rsnapshot-cp-btrfs:
```shell
#!/bin/sh
# rsnapshot will pass the last backup directory
# as $2 and the destination as $3. $1 contains
# additional cp arguments ('-al') that we ignore.
btrfs subvolume snapshot $2 $3
```

rsnapshot-rm-btrfs:
```shell
#!/bin/sh
# rsnapshot will pass the directory to be deleted as $2.
# $1 contains rm arguments ('-rf') that we ignore.
btrfs subvolume delete $2
```

rsnapshot-mkbackupdir-btrfs
```shell
#!/bin/sh
# rsnapshot will pass the directory to be created as $4.
# The other arguments contain additional options:
# $1: "-m" string
# $2: permissions for directory (e.g. 0755)
# $3: "-p" string
btrfs subvolume create $4
chmod $2 
```