### PR TITLE
Fixes shortargs appending

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3684,8 +3684,8 @@ sub rsync_backup_point {
 		$rsync_short_args = $$bp_ref{'opts'}->{'rsync_short_args'};
 	}
 	if (defined($$bp_ref{'opts'}) && defined($$bp_ref{'opts'}->{'extra_rsync_short_args'})) {
-		$rsync_short_args .= ' ' if ($rsync_short_args);
-		$rsync_short_args .= $$bp_ref{'opts'}->{'extra_rsync_short_args'};
+		$rsync_short_args .= '-' if (!$rsync_short_args);
+		$rsync_short_args .= substr $$bp_ref{'opts'}->{'extra_rsync_short_args'}, 1;
 	}
 
 	# RSYNC LONG ARGS


### PR DESCRIPTION
Consider following example backup endpoint
```
backup	rsync://rsync.samba.org/rsyncftp/	rsync.samba.org/rsyncftp/	+rsync_short_args=-z
```
Before it caused rsnapshot to run rsync with single `"-a -z"` argument and this behavior is definitely incorrect. So, it seems, `+rsync_short_args` never worked properly before.