### PR TITLE
Add basic test for long and short args. 

### DIFF
--- a/t/long_and_short_args/conf/long_and_short_args.conf.in
+++ b/t/long_and_short_args/conf/long_and_short_args.conf.in
@@ -1,0 +1,10 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+cmd_cp	@CP@
+interval		hourly	2
+sync_first	1
+rsync_short_args	-z
+rsync_long_args	--archive
+backup	@TEMP@		long_and_short_args/
+backup	@TEMP@		long_and_short_args/

--- a/t/long_and_short_args/conf/long_and_short_args_inline.conf.in
+++ b/t/long_and_short_args/conf/long_and_short_args_inline.conf.in
@@ -1,0 +1,8 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+cmd_cp	@CP@
+interval		hourly	2
+sync_first	1
+backup	@TEMP@		long_and_short_args_inline/	+rsync_short_args=-z
+backup	@TEMP@		long_and_short_args_inline/	+rsync_long_args=--archive

--- a/t/long_and_short_args/long_and_short_args.t.in
+++ b/t/long_and_short_args/long_and_short_args.t.in
@@ -1,0 +1,11 @@
+#!@PERL@
+use strict;
+use Test::More tests => 2; # pack here your amount of subtests
+use SysWrap;
+
+#
+# This test merely confirms rsync doesn't blow up with long & short args. Previously it did.
+#
+
+ok(0 == rsnapshot("-c @TEST@/long_and_short_args/conf/long_and_short_args.conf sync"));
+ok(0 == rsnapshot("-c @TEST@/long_and_short_args/conf/long_and_short_args_inline.conf sync"));


### PR DESCRIPTION
Simply confirm rsnapshot accepts long|short inline or not  args without blowing up. The test can be elaborated on later. Currently rsnapshot blows up on inline short args, so they currently don'e actually worked. #156 fixes that.