### PR TITLE
Fixed headers on howto page

### DIFF
--- a/docs/HOWTOs/rsnapshot-HOWTO.en.html
+++ b/docs/HOWTOs/rsnapshot-HOWTO.en.html
@@ -240,7 +240,7 @@ alink="#0000FF">
         <div>
           <div>
             <h2 class="title" style="clear: both"><a name=
-            "intro"></a>1.&#194;&nbsp;Introduction</h2>
+            "intro"></a>1.&nbsp;Introduction</h2>
           </div>
         </div>
       </div>
@@ -269,7 +269,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "what_you_will_need"></a>1.1.&#194;&nbsp;What you
+              "what_you_will_need"></a>1.1.&nbsp;What you
               will need</h3>
             </div>
           </div>
@@ -285,7 +285,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "copyright"></a>1.2.&#194;&nbsp;Copyright and
+              "copyright"></a>1.2.&nbsp;Copyright and
               License</h3>
             </div>
           </div>
@@ -305,7 +305,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "disclaimer"></a>1.3.&#194;&nbsp;Disclaimer</h3>
+              "disclaimer"></a>1.3.&nbsp;Disclaimer</h3>
             </div>
           </div>
         </div>
@@ -327,7 +327,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "feedback"></a>1.4.&#194;&nbsp;Feedback</h3>
+              "feedback"></a>1.4.&nbsp;Feedback</h3>
             </div>
           </div>
         </div>
@@ -342,7 +342,7 @@ alink="#0000FF">
         <div>
           <div>
             <h2 class="title" style="clear: both"><a name=
-            "motivation"></a>2.&#194;&nbsp;Motivation</h2>
+            "motivation"></a>2.&nbsp;Motivation</h2>
           </div>
         </div>
       </div>
@@ -382,7 +382,7 @@ alink="#0000FF">
         <div>
           <div>
             <h2 class="title" style="clear: both"><a name=
-            "installation"></a>3.&#194;&nbsp;Installation</h2>
+            "installation"></a>3.&nbsp;Installation</h2>
           </div>
         </div>
       </div>
@@ -399,7 +399,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "thirty_second_version"></a>3.1.&#194;&nbsp;30 second
+              "thirty_second_version"></a>3.1.&nbsp;30 second
               version (for the impatient)</h3>
             </div>
           </div>
@@ -418,7 +418,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "untar_the_source_code_package"></a>3.2.&#194;&nbsp;Untar
+              "untar_the_source_code_package"></a>3.2.&nbsp;Untar
               the source code package</h3>
             </div>
           </div>
@@ -438,7 +438,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "change_to_src_dir"></a>3.3.&#194;&nbsp;Change to the
+              "change_to_src_dir"></a>3.3.&nbsp;Change to the
               source directory</h3>
             </div>
           </div>
@@ -452,7 +452,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "decide_where_to_install"></a>3.4.&#194;&nbsp;Decide
+              "decide_where_to_install"></a>3.4.&nbsp;Decide
               where you want to install</h3>
             </div>
           </div>
@@ -482,7 +482,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "run_the_configure_script"></a>3.5.&#194;&nbsp;Run
+              "run_the_configure_script"></a>3.5.&nbsp;Run
               the configure script</h3>
             </div>
           </div>
@@ -515,7 +515,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "install_the_program"></a>3.6.&#194;&nbsp;Install the
+              "install_the_program"></a>3.6.&nbsp;Install the
               program</h3>
             </div>
           </div>
@@ -559,7 +559,7 @@ alink="#0000FF">
         <div>
           <div>
             <h2 class="title" style="clear: both"><a name=
-            "configuration"></a>4.&#194;&nbsp;Configuration</h2>
+            "configuration"></a>4.&nbsp;Configuration</h2>
           </div>
         </div>
       </div>
@@ -568,7 +568,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "create_the_config_file"></a>4.1.&#194;&nbsp;Create
+              "create_the_config_file"></a>4.1.&nbsp;Create
               the config file</h3>
             </div>
           </div>
@@ -600,7 +600,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "where_to_go_for_more_info"></a>4.2.&#194;&nbsp;Where
+              "where_to_go_for_more_info"></a>4.2.&nbsp;Where
               to go for more info</h3>
             </div>
           </div>
@@ -629,7 +629,7 @@ alink="#0000FF">
           <div>
             <div>
               <h3 class="title"><a name=
-              "modifying_the_config_file"></a>4.3.&#194;&nbsp;Modifying
+              "modifying_the_config_file"></a>4.3.&nbsp;Modifying
               the config file</h3>
             </div>
           </div>
@@ -651,7 +651,7 @@ alink="#0000FF">
             <div>
               <div>
                 <h4 class="title"><a name=
-                "cmd_cp"></a>4.3.1.&#194;&nbsp;cmd_cp</h4>
+                "cmd_cp"></a>4.3.1.&nbsp;cmd_cp</h4>
               </div>
             </div>
           </div>
@@ -692,7 +692,7 @@ alink="#0000FF">
             <div>
               <div>
                 <h4 class="title"><a name=
-                "cmd_rsync"></a>4.3.2.&#194;&nbsp;cmd_rsync</h4>
+                "cmd_rsync"></a>4.3.2.&nbsp;cmd_rsync</h4>
               </div>
             </div>
           </div>
@@ -713,7 +713,7 @@ alink="#0000FF">
             <div>
               <div>
                 <h4 class="title"><a name=
-                "cmd_ssh"></a>4.3.3.&#194;&nbsp;cmd_ssh</h4>
+                "cmd_ssh"></a>4.3.3.&nbsp;cmd_ssh</h4>
               </div>
             </div>
           </div>
@@ -731,7 +731,7 @@ alink="#0000FF">
             <div>
               <div>
                 <h4 class="title"><a name=
-                "cmd_logger"></a>4.3.4.&#194;&nbsp;cmd_logger</h4>
+                "cmd_logger"></a>4.3.4.&nbsp;cmd_logger</h4>
               </div>
             </div>
           </div>
@@ -753,7 +753,7 @@ alink="#0000FF">
             <div>
               <div>
                 <h4 class="title"><a name=
-                "cmd_du"></a>4.3.5.&#194;&nbsp;cmd_du</h4>
+                "cmd_du"></a>4.3.5.&nbsp;cmd_du</h4>
               </div>
             </div>
           </div>
@@ -780,7 +780,7 @@ alink="#0000FF">
             <div>
               <div>
                 <h4 class="title"><a name=
-                "link_dest"></a>4.3.6.&#194;&nbsp;link_dest</h4>
+                "link_dest"></a>4.3.6.&nbsp;link_dest</h4>
               </div>
             </div>
           </div>
@@ -803,7 +803,7 @@ alink="#0000FF">
             <div>
               <div>
                 <h4 class="title"><a name=
-                "interval"></a>4.3.7.&#194;&nbsp;interval</h4>
+                "interval"></a>4.3.7.&nbsp;interval</h4>
               </div>
             </div>
           </div>
@@ -850,7 +850,7 @@ interval    daily   7
             <div>
               <div>
                 <h4 class="title"><a name=
-                "backup"></a>4.3.8.&#194;&nbsp;backup</h4>
+                "backup"></a>4.3.8.&nbsp;backup</h4>
               </div>
             </div>
           </div>
@@ -948,7 +948,7 @@ backup      root@example.com:/etc/     example.com/
             <div>
               <div>
                 <h4 class="title"><a name=
-                "backup_script"></a>4.3.9.&#194;&nbsp;backup_script</h4>
+                "backup_script"></a>4.3.9.&nbsp;backup_script</h4>
               </div>
             </div>
           </div>
@@ -1008,7 +1008,7 @@ backup_script      /usr/local/bin/backup_pgsql.sh       localhost/postgres/
           <div>
             <div>
               <h3 class="title"><a name=
-              "testing_your_config_file"></a>4.4.&#194;&nbsp;Testing
+              "testing_your_config_file"></a>4.4.&nbsp;Testing
               your config file</h3>
             </div>
           </div>
@@ -1049,7 +1049,7 @@ backup_script      /usr/local/bin/backup_pgsql.sh       localhost/postgres/
         <div>
           <div>
             <h2 class="title" style="clear: both"><a name=
-            "automation"></a>5.&#194;&nbsp;Automation</h2>
+            "automation"></a>5.&nbsp;Automation</h2>
           </div>
         </div>
       </div>
@@ -1082,7 +1082,7 @@ backup_script      /usr/local/bin/backup_pgsql.sh       localhost/postgres/
         <div>
           <div>
             <h2 class="title" style="clear: both"><a name=
-            "how_it_works"></a>6.&#194;&nbsp;How it works</h2>
+            "how_it_works"></a>6.&nbsp;How it works</h2>
           </div>
         </div>
       </div>
@@ -1169,7 +1169,7 @@ backup          /etc/           localhost/
         <div>
           <div>
             <h2 class="title" style="clear: both"><a name=
-            "restoring_backups"></a>7.&#194;&nbsp;Restoring
+            "restoring_backups"></a>7.&nbsp;Restoring
             backups</h2>
           </div>
         </div>
@@ -1193,7 +1193,7 @@ backup          /etc/           localhost/
           <div>
             <div>
               <h3 class="title"><a name=
-              "root_only"></a>7.1.&#194;&nbsp;root only</h3>
+              "root_only"></a>7.1.&nbsp;root only</h3>
             </div>
           </div>
         </div>
@@ -1212,7 +1212,7 @@ backup          /etc/           localhost/
           <div>
             <div>
               <h3 class="title"><a name=
-              "all_users"></a>7.2.&#194;&nbsp;All users</h3>
+              "all_users"></a>7.2.&nbsp;All users</h3>
             </div>
           </div>
         </div>
@@ -1297,7 +1297,7 @@ localhost:/.private/.snapshots/   /.snapshots/   nfs    ro   0 0
         <div>
           <div>
             <h2 class="title" style="clear: both"><a name=
-            "conclusion"></a>8.&#194;&nbsp;Conclusion</h2>
+            "conclusion"></a>8.&nbsp;Conclusion</h2>
           </div>
         </div>
       </div>
@@ -1336,7 +1336,7 @@ localhost:/.private/.snapshots/   /.snapshots/   nfs    ro   0 0
         <div>
           <div>
             <h2 class="title" style="clear: both"><a name=
-            "more_resources"></a>9.&#194;&nbsp;More resources</h2>
+            "more_resources"></a>9.&nbsp;More resources</h2>
           </div>
         </div>
       </div>


### PR DESCRIPTION
&#194;&nbsp; was displaying as "Â ", encoding issue. Tested on latest versions of MS Edge, chrome, firefox.