### PR TITLE
Update "interval" to "retain" in man page text for consistency

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -7171,7 +7171,7 @@ B<backup  lvm://vg0/home/path2/       lvm-vg0/>
 =over 4
 
 Backs up the LVM logical volume called home, of volume group vg0, to
-<snapshot_root>/<interval>.0/lvm-vg0/. Will create, mount, backup, unmount and remove an LVM
+<snapshot_root>/<retain>.0/lvm-vg0/. Will create, mount, backup, unmount and remove an LVM
 snapshot for each lvm:// entry.
 
 =back


### PR DESCRIPTION
The documentation text in `rsnapshot-program.pl` uses examples with the path `<snapshot_root>/<retain>.0`, except for for one remaining case of `<interval>.0`.  This just changes that one instance of "interval" to "retain" to match the others, so the generated man page is consistent.