### PR TITLE
Fixed a bug which happens if you set 'sync_firsti'; The error is

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3497,10 +3497,10 @@ sub rotate_lowest_snapshots {
 			if (-d "$config_vars{'snapshot_root'}/.sync/") {
 				display_cp_al("$config_vars{'snapshot_root'}/.sync/", "$config_vars{'snapshot_root'}/$interval.0/");
 				if (0 == $test) {
-					$result = cp_al("$config_vars{'snapshot_root'}/.sync", "$config_vars{'snapshot_root'}/$interval.0");
+					$result = cp_al("$config_vars{'snapshot_root'}/.sync/", "$config_vars{'snapshot_root'}/$interval.0/");
 					if (!$result) {
 						bail(
-							"Error! cp_al(\"$config_vars{'snapshot_root'}/.sync\", \"$config_vars{'snapshot_root'}/$interval.0\")"
+							"Error! cp_al(\"$config_vars{'snapshot_root'}/.sync/\", \"$config_vars{'snapshot_root'}/$interval.0/\")"
 						);
 					}
 				}


### PR DESCRIPTION
triggered at the time of rotation like this:

----------------------------------------------------------------------------
rsnapshot encountered an error! The program was invoked with these
options:
/usr/bin/rsnapshot hourly
----------------------------------------------------------------------------
ERROR: rsync_cleanup_after_native_cp_al() only works on directories
ERROR: Error! cp_al("/.snapshots/.sync", "/.snapshots/hourly.0")