### PR TITLE
Restored rsync error code 23 as an important warning

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -4201,7 +4201,7 @@ sub handle_rsync_error {
 	elsif (23 == $retval) {
 		print_warn(
 			"Some files and/or directories in $$bp_ref{'src'} only transferred partially during rsync operation",
-			4
+			2
 		);
 		syslog_warn(
 			"Some files and/or directories in $$bp_ref{'src'} only transferred partially during rsync operation"


### PR DESCRIPTION
After poking around with source code, I found that `rsync` error codes `23` and`24` are considered "minor warnings" and are not shown when `verbose < 4`.

While for error code `24` this is very sane (as rsync run on "live" filesystem often emits spurious "file has vanished" warnings), it is quite dangerous to ignore error code `23`, as the latter is emitted when something prevented `rsync` to fully scan/transfer the source directory.

For example, trying to rsync a non existent or mispelled remote directory (as by the example above) return *no* warnings on the command line, and this is clearly misleading.

I strongly suggest to change line 4202 from `4` to `2`, restoring "normal" warning weight for error code `23`