### PR TITLE
Rm redundant and erroneous check in rsync_cleanup_after_native_cp_al()

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -5145,12 +5145,6 @@ sub rsync_cleanup_after_native_cp_al {
 	if (!defined($src))  { return (0); }
 	if (!defined($dest)) { return (0); }
 
-	# make sure this is directory to directory
-	if (($src !~ m/\/$/o) or ($dest !~ m/\/$/o)) {
-		print_err("rsync_cleanup_after_native_cp_al() only works on directories", 2);
-		return (0);
-	}
-
 	# make sure we have a source directory
 	if (!-d "$src") {
 		print_err("rsync_cleanup_after_native_cp_al() needs a valid source directory as an argument", 2);


### PR DESCRIPTION
Remove redundant and erroneous check in [check in rsync_cleanup_after_native_cp_al()](https://github.com/rsnapshot/rsnapshot/edit/master/rsnapshot-program.pl#L5149). Refs #133.

This function does some post work when `cmd_cp` is not set (normally in non GNU/Linux systems). Function seems to have redundant check if src and dest of cp are directories (i.e. does `$src !~ m/\/$/o` which is obviously fallible). That src and dest are directories were already being checked in the immediately following lines ... so just rm erroneous check.