### PR TITLE
Fix error when file matching "/rsync*" in backup.

### DIFF
--- a/utils/rsnapreport.pl
+++ b/utils/rsnapreport.pl
@@ -72,7 +72,7 @@ for(my $i=0; $i < $bufsz; $i++){
 }
 
 while (my $line = nextLine(\@rsnapout)){
-	if($line =~ /^[\/\w]+\/rsync/) { # find start rsync command line
+	if($line =~ /^[\/\w]+\/rsync\s+-/) { # find start rsync command line
 		my @rsynccmd=();
 		while($line =~ /\s+\\$/){ # combine wrapped lines
 			$line =~ s/\\$//g;
@@ -83,7 +83,7 @@ while (my $line = nextLine(\@rsnapout)){
 		#print $source;
 		while($line = nextLine(\@rsnapout)){
   			# this means we are missing stats info
-			if($line =~ /^[\/\w]+\/rsync/){
+			if($line =~ /^[\/\w]+\/rsync\s+-/){
 				unshift(@rsnapout,$line);
 				push(@errors,"$source NO STATS DATA");
 				last;


### PR DESCRIPTION
The script synchronises with the output from rsnapshot by looking for the command line invoking rsync. The regex is too loose, so a false match will occur if any file matching "/rsync*" is in the backup - this means that backup of the root filesystem will always error when it gets to the rsync binary. The change tightens the regex to reduce the chance of a false match.