### PR TITLE
Fix missing fakeroot in latest Travis image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ perl:
   - "5.18"
   - "5.16"
   - "5.14"
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y fakeroot
 install:
   - "./autogen.sh"
   - "./configure"


### PR DESCRIPTION
This is option 1: Re-install fakeroot before building [tested - works fine]

See issue #186.