### PR TITLE
fix location of true and false binaries on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,61 @@ fi
 dnl either way, set the cmd_cp var
 AC_SUBST(CMD_CP, "cmd_cp		$CP")
 
+dnl
+dnl TRUE CHECK (required test program)
+dnl
+dnl if the user specified a path, try that first
+AC_ARG_WITH(true,
+	[  --with-true=PATH          Specify the path to true ],
+	[
+		if test "x$withval" != "xno"; then
+			if test -x "$withval"; then
+				TRUE=$withval
+			else
+				AC_MSG_ERROR(true not found)
+			fi
+		else
+			TRUE=no
+		fi
+	]
+)
+
+dnl if the user didn't specify a path, hunt for it
+if test "$TRUE" != "no"; then
+	AC_PATH_PROG(TRUE, true, no)
+fi
+dnl if we couldn't find it, provide an example
+if test "$TRUE" = "no"; then
+	TRUE=/bin/true
+fi
+
+dnl
+dnl FALSE CHECK (required test program)
+dnl
+dnl if the user specified a path, try that first
+AC_ARG_WITH(false,
+	[  --with-false=PATH          Specify the path to false ],
+	[
+		if test "x$withval" != "xno"; then
+			if test -x "$withval"; then
+				FALSE=$withval
+			else
+				AC_MSG_ERROR(false not found)
+			fi
+		else
+			FALSE=no
+		fi
+	]
+)
+
+dnl if the user didn't specify a path, hunt for it
+if test "$FALSE" != "no"; then
+	AC_PATH_PROG(FALSE, false, no)
+fi
+dnl if we couldn't find it, provide an example
+if test "$FALSE" = "no"; then
+	FALSE=/bin/false
+fi
 
 
 dnl

--- a/t/backup_exec/conf/backup_exec.conf.in
+++ b/t/backup_exec/conf/backup_exec.conf.in
@@ -5,8 +5,8 @@ interval		hourly	2
 backup_exec		ls -ld /* | grep "/u"
 backup_exec		echo "hello world!"
 backup_exec		echo 'hello world!'
-backup_exec		/bin/true
-backup_exec		/bin/true		optional
-backup_exec		/bin/true		required
-backup_exec		/bin/false
-backup_exec		/bin/false	optional
+backup_exec		@TRUE@
+backup_exec		@TRUE@		optional
+backup_exec		@TRUE@		required
+backup_exec		@FALSE@
+backup_exec		@FALSE@	optional

--- a/t/backup_exec/conf/backup_exec_fail.conf.in
+++ b/t/backup_exec/conf/backup_exec_fail.conf.in
@@ -2,4 +2,4 @@ config_version	1.2
 snapshot_root	@SNAP@
 cmd_rsync		@RSYNC@
 interval		hourly	2
-backup_exec		/bin/false	required
+backup_exec		@FALSE@	required

--- a/t/cmd-post_pre-exec/conf/pre-false-post-false.conf.in
+++ b/t/cmd-post_pre-exec/conf/pre-false-post-false.conf.in
@@ -5,7 +5,7 @@ cmd_rsync		@RSYNC@
 
 interval		hourly	2
 
-cmd_preexec	/bin/false
-cmd_postexec	/bin/false
+cmd_preexec	@FALSE@
+cmd_postexec	@FALSE@
 
 backup	@TEMP@	cmd_pre_postexectest/

--- a/t/cmd-post_pre-exec/conf/pre-false-post-true.conf.in
+++ b/t/cmd-post_pre-exec/conf/pre-false-post-true.conf.in
@@ -5,7 +5,7 @@ cmd_rsync		@RSYNC@
 
 interval		hourly	2
 
-cmd_preexec	/bin/false
-cmd_postexec	/bin/true
+cmd_preexec	@FALSE@
+cmd_postexec	@TRUE@
 
 backup	@TEMP@		cmd_pre_postexectest/

--- a/t/cmd-post_pre-exec/conf/pre-true-post-false.conf.in
+++ b/t/cmd-post_pre-exec/conf/pre-true-post-false.conf.in
@@ -5,7 +5,7 @@ cmd_rsync		@RSYNC@
 
 interval		hourly	2
 
-cmd_preexec	/bin/true
-cmd_postexec	/bin/false
+cmd_preexec	@TRUE@
+cmd_postexec	@FALSE@
 
 backup	@TEMP@		cmd_pre_postexectest/

--- a/t/cmd-post_pre-exec/conf/pre-true-post-true.conf.in
+++ b/t/cmd-post_pre-exec/conf/pre-true-post-true.conf.in
@@ -5,7 +5,7 @@ cmd_rsync		@RSYNC@
 
 interval		hourly	2
 
-cmd_preexec	/bin/true
-cmd_postexec	/bin/true
+cmd_preexec	@TRUE@
+cmd_postexec	@TRUE@
 
 backup	@TEMP@		cmd_pre_postexectest/

--- a/t/configtest/conf/configtest.conf.in
+++ b/t/configtest/conf/configtest.conf.in
@@ -3,6 +3,6 @@ snapshot_root	@SNAP@
 cmd_rsync		@RSYNC@
 interval		hourly	6
 backup			@TEMP@/a/	localhost/
-backup_exec		/bin/true
-backup_exec		/bin/true		optional
-backup_exec		/bin/true		required
+backup_exec		@TRUE@
+backup_exec		@TRUE@		optional
+backup_exec		@TRUE@		required

--- a/t/rsync-exitcode/conf/rsync-exitcode-bad.conf.in
+++ b/t/rsync-exitcode/conf/rsync-exitcode-bad.conf.in
@@ -1,5 +1,5 @@
 config_version	1.2
 snapshot_root	@SNAP@
-cmd_rsync		/bin/false
+cmd_rsync		@FALSE@
 interval		hourly	6
 backup			@TEST@/support/files/a/	localhost/


### PR DESCRIPTION
Offer new options in configure to set the path to true/false or, if not set, search for them

See issue #188. 

(This passes the Travis build `fakeroot` issue as the builds used an older image of Ubuntu)

Personally tested on the systems below.

### Ubuntu 16.04.1 (4.8.0-53-generic)
````bash
All tests successful.
Files=11, Tests=33, 13 wallclock secs ( 0.03 usr  0.01 sys +  1.06 cusr  0.11 csys =  1.21 CPU)
Result: PASS
james@james-ubuntu:~/rsnapshot$ uname -a
Linux james-ubuntu 4.8.0-53-generic \
56~16.04.1-Ubuntu SMP Tue May 16 01:18:56 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
james@james-ubuntu:~/rsnapshot$ git rev-parse --abbrev-ref HEAD
issue/188-fix-macos-tests
````
### macOS 10.12.5 (Kernel Version 16.6.0)
````bash
All tests successful.
Files=11, Tests=33, 11 wallclock secs ( 0.05 usr  0.05 sys +  1.42 cusr  0.54 csys =  2.06 CPU)
Result: PASS
$ uname -a
Darwin Jamess-iMac 16.6.0 Darwin Kernel Version \
16.6.0: Fri Apr 14 16:21:16 PDT 2017; root:xnu-3789.60.24~6/RELEASE_X86_64 x86_64
james@Jamess-iMac: ~/Projects/rsnapshot on issue/188-fix-macos-tests
$ git rev-parse --abbrev-ref HEAD
issue/188-fix-macos-tests
````
### OpenSolaris 11 (SunOS 5.11 snv_134)
````bash
All tests successful.
Files=11, Tests=33, 12 wallclock secs ( 0.07 usr  0.03 sys +  2.00 cusr  0.22 csys =  2.32 CPU)
Result: PASS
$ uname -a
SunOS dusky 5.11 snv_134 i86pc i386 i86pc
james@dusky: ~/rsnapshot
$ git rev-parse --abbrev-ref HEAD
issue/188-fix-macos-tests
````