### PR TITLE
Lower verbose level of rsync output requirement

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3916,7 +3916,7 @@ sub rsync_backup_point {
 			$rsync_out->autoflush();
 
 			while (<$rsync_out>) {
-				print_msg($_, 4);
+				print_msg($_, 3);
 			}
 
 			waitpid($pid, 0);


### PR DESCRIPTION
Lower verbose level of rsync output to 1.3.x equivalent to work with rsnapreport.pl again.

With the rsnapshot verbose level at 4, rsync's verbose level is far too noisy and rsnapreport.pl shows many bad parsing matches.

This brings it back to the 1.3.x behavior of output level which works with the reporting tool as well.