### PR TITLE
fix rsnapreport problems (incorrect header, fail when rsync present, fail with LVM)

### DIFF
--- a/utils/rsnapreport.pl
+++ b/utils/rsnapreport.pl
@@ -72,7 +72,7 @@ for(my $i=0; $i < $bufsz; $i++){
 }
 
 while (my $line = nextLine(\@rsnapout)){
-	if($line =~ /^[\/\w]+\/rsync/) { # find start rsync command line
+	if($line =~ /^[\/\w]+\/rsync\h+-[-\w]/) { # find start rsync command line
 		my @rsynccmd=();
 		while($line =~ /\s+\\$/){ # combine wrapped lines
 			$line =~ s/\\$//g;
@@ -83,7 +83,7 @@ while (my $line = nextLine(\@rsnapout)){
 		#print $source;
 		while($line = nextLine(\@rsnapout)){
   			# this means we are missing stats info
-			if($line =~ /^[\/\w]+\/rsync/){
+			if($line =~ /^[\/\w]+\/rsync\h+-[-\w]/){
 				unshift(@rsnapout,$line);
 				push(@errors,"$source NO STATS DATA");
 				last;

--- a/utils/rsnapreport.pl
+++ b/utils/rsnapreport.pl
@@ -45,7 +45,7 @@ sub pretty_print(){
 		my $bytest = $bkdata{$source}{'file_tran_size'}/1000000; # convert to MB
 		$source =~ s/^[^\@]+\@//; # remove username
 		format BREPORTHEAD =
-SOURCE                          TOTAL FILES   FILES TRANS      TOTAL MB     MB TRANS   LIST GEN TIME  FILE XFER TIME
+SOURCE                          TOTAL FILES   FILES TRANS      TOTAL MB     MB TRANS   LIST GEN TIME  LIST XFER TIME
 --------------------------------------------------------------------------------------------------------------------
 .
 		format BREPORTBODY =

--- a/utils/rsnapreport.pl
+++ b/utils/rsnapreport.pl
@@ -5,6 +5,9 @@
 # and add --stats to rsync_long_args
 # then setup crontab 'rsnapshot daily 2>&1 | rsnapreport.pl | mail -s"SUBJECT" backupadm@adm.com
 # don't forget the 2>&1 or your errors will be lost to stderr
+# If you would prefer to leave the rsnapshot.conf verbose value unchanged,
+# an alternative is to pass the -V option to rsnapshot.
+# For example: rsnapshot -V daily 2>&1 | rsnapreport.pl
 ################################
 ## Copyright 2006 William Bear
 ## This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
I encountered several issues when using rsnapreport.

The report header said FILE XFER TIME, but the time value is really the file list transfer time.

If there is a file named rsync in the file list, this confuses rsnapreport. Note that my fix isn't perfect. A pathological filename like "rsync -a" would trip it up.  Nonetheless, it's better than before.

If there was more than one LVM backup point, only the data from the last one would be output, and it would be named ./ rather than something related to the actual backup point. Now each LVM backup point has its own line, and the filesystem name under the SOURCE heading is directly related to the logical volume.

Finally, the code says to change the rsnapshot.conf verbose value to 4 in order to use rsnapreport, but this is not necessary if you pass the '-V' to rsnapshot.
