### PR TITLE
Log rsnapshot pid into log file on each message line.

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -2257,7 +2257,7 @@ sub log_msg {
 				exit(1);
 			}
 
-			print LOG '[', get_current_date(), '] ', $str, "\n";
+			print LOG '[', get_current_date(), '][', $$, '] ', $str, "\n";
 
 			$result = close(LOG);
 			if (!defined($result)) {


### PR DESCRIPTION
Log rsnapshot pid in every log line, so it is easy to distinguish
lines belonging to particular rsnapshot call. It is easier to parse
and grep log file for all logs from some rsnapshot invocation.

Fixes #222.