### PR TITLE
Fix for 'rsync_cleanup_after_native_cp_al() only works on directories' fail when sync_first on and cmd_cp not set (#133).

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -5145,12 +5145,6 @@ sub rsync_cleanup_after_native_cp_al {
 	if (!defined($src))  { return (0); }
 	if (!defined($dest)) { return (0); }
 
-	# make sure this is directory to directory
-	if (($src !~ m/\/$/o) or ($dest !~ m/\/$/o)) {
-		print_err("rsync_cleanup_after_native_cp_al() only works on directories", 2);
-		return (0);
-	}
-
 	# make sure we have a source directory
 	if (!-d "$src") {
 		print_err("rsync_cleanup_after_native_cp_al() needs a valid source directory as an argument", 2);
@@ -5163,6 +5157,10 @@ sub rsync_cleanup_after_native_cp_al {
 			2);
 		return (0);
 	}
+
+	# make sure src and dest both have a trailing slash for rsync
+	$src =~ s/\/?$/\//;
+	$dest =~ s/\/?$/\//;
 
 	# check verbose settings and modify rsync's short args accordingly
 	if ($verbose > 3) { $local_rsync_short_args .= 'v'; }
@@ -5289,7 +5287,7 @@ sub rm_rf {
 
 	# added by Matthew Jurgens as part of the fix for rm -rf failing when the path contains ./
 	# make sure the directory is still in place
-	# if you cannot create this directory and this rm is part of a rollback which uses cp -al, then the cp -al will fail shortly after 
+	# if you cannot create this directory and this rm is part of a rollback which uses cp -al, then the cp -al will fail shortly after
 	# MKDIR DEST (AND SET MODE)
 	if (defined($st)) {
 		# create the directory

--- a/t/native_cp_al/conf/native_cp_al.conf.in
+++ b/t/native_cp_al/conf/native_cp_al.conf.in
@@ -1,0 +1,7 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+sync_first	1
+link_dest	0
+interval		hourly	6
+backup			@TEMP@	native_cp_al

--- a/t/native_cp_al/native_cp_al.t.in
+++ b/t/native_cp_al/native_cp_al.t.in
@@ -1,0 +1,26 @@
+#!@PERL@
+use strict;
+use Test::More tests => 6;
+use SysWrap;
+
+#
+# Test native_cp_al works with cmd_cp option not set and sync_first on (see contig).
+#
+
+ok(! remove_snapshot_root(),
+	" snapshot root does not exist before testing starts");
+
+ok(0 == rsnapshot("-c @TEST@/native_cp_al/conf/native_cp_al.conf sync 2>&1"),
+	" sync success");
+
+ok(-d "@SNAP@/.sync/native_cp_al",
+	" sync directory exists");
+
+ok(0 == rsnapshot("-c @TEST@/native_cp_al/conf/native_cp_al.conf hourly 2>&1"),
+	" hourly backup after sync success");
+
+ok(-d "@SNAP@/hourly.0/native_cp_al",
+	" hourly backup directory exists");
+
+ok(0 == remove_snapshot_root(),
+	" Removed snapshot root to clean up");


### PR DESCRIPTION
Refs #133. Solves same issue as #177. IMO better than #177 since it's clear why ending slashes are needed and they are only added exactly where they are needed. Also adds includes a test case. 