### PR TITLE
Fix regression in 262

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -1677,21 +1677,14 @@ sub validate_config_file {
 			# skip for backup_exec since it uses no destination
 			next if (defined($$bp_ref{'cmd'}));
 
-			my $tmp_dest_path = $$bp_ref{'dest'};
-
-			# normalize multiple slashes, and strip trailing slash
-			# FIXME: Decide whether to allow an empty destination path, and reject or handle such paths accordingly.
-			$tmp_dest_path =~ s/\/+/\//g;
-			$tmp_dest_path =~ s/\/$//;
-
 			# backup
 			if (defined($$bp_ref{'src'})) {
-				push(@backup_dest, $tmp_dest_path);
+				push(@backup_dest, $$bp_ref{'dest'});
 
 				# backup_script
 			}
 			elsif (defined($$bp_ref{'script'})) {
-				push(@backup_script_dest, $tmp_dest_path);
+				push(@backup_script_dest, $$bp_ref{'dest'});
 
 			}
 

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3050,19 +3050,6 @@ sub remove_trailing_slash {
 	return ($str);
 }
 
-# accepts string
-# returns /. if passed /, returns input otherwise
-# this is to work around a bug in some versions of rsync
-sub add_slashdot_if_root {
-	my $str = shift(@_);
-
-	if ($str eq '/') {
-		return '/.';
-	}
-
-	return ($str);
-}
-
 # accepts the interval (cmd) to run against
 # returns nothing
 # calls the appropriate subroutine, depending on whether this is the lowest interval or a higher one


### PR DESCRIPTION
Revert changes from #262 (rm -rf failure case on abnormal termination). Add replacement fix. Ref #282. Confirmed fixed according to informal test case in #282. 

The changes in #262 are in the wrong place in view. It's better to try and normalize file paths further upstream as far as possible, rather than trying to have `rm_rf()` sub, which is used in many places, try and address a specific usage case.

Of course the risk is change further upstream means different downstream parts of code see a different value than they did before. But A. it's only for certain backup destination paths B. Changes are minor C. Fixes this issue.