### PR TITLE
Pr/151 tests - subdirectories test for multiple subdirectory configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,3 @@ t/*.pm
 t/*/*.t
 t/*/conf/*.conf
 t/support/snapshots/
-t/support/files/inc_dir_test/
-t/support/files/inc_conf_test/
-t/include_conf/conf/bad_include_file
-t/include_conf/conf/include_file
-t/include_conf_dir/conf/include.d/include_dir.conf
-t/include_conf_dir/conf/include.inc.d/include_dir.inc
-t/include_conf_dir/conf/include.conf.d/include_dir.conf

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,10 @@ t/*.pm
 t/*/*.t
 t/*/conf/*.conf
 t/support/snapshots/
+t/support/files/inc_dir_test/
+t/support/files/inc_conf_test/
+t/include_conf/conf/bad_include_file
+t/include_conf/conf/include_file
+t/include_conf_dir/conf/include.d/include_dir.conf
+t/include_conf_dir/conf/include.inc.d/include_dir.inc
+t/include_conf_dir/conf/include.conf.d/include_dir.conf

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -618,6 +618,29 @@ sub parse_config_file {
 			}
 		}
 
+		# Include from a directory
+		if ($var eq 'include_conf_dir') {
+			my $conf_pat = '';
+			if (defined($value) && -d $value && -r $value) {
+			# Check for a regex filter, default to .conf if not specified
+			if (defined($value2)) {
+				$conf_pat = $value2;
+				} else {
+				$conf_pat = '.*\.conf$';
+				}
+				opendir(CONF_DIR, $value) or die $!;
+				while (my $conf_file = readdir(CONF_DIR)) {
+					if ( -f "$value/$conf_file" && ($conf_file =~ m/$conf_pat/) ) {
+					parse_config_file("$value/$conf_file");
+					}
+				}
+				closedir(CONF_DIR);
+				next;
+			} else {
+				config_err($file_line_num, "$line - can't find or read directory '$value'");
+			}
+
+		}
 		# CONFIG_VERSION
 		if ($var eq 'config_version') {
 			if (defined($value)) {
@@ -6713,6 +6736,29 @@ path.  As a special case, include_conf's value may be enclosed in `backticks`
 in which case it will be executed and whatever it spits to STDOUT will
 be included in the configuration.  Note that shell meta-characters may be
 interpreted.
+
+=back
+
+B<include_conf_dir [conf-file-pattern=*\.conf]>   Include any files in this directory at this point. By default only ending in .conf are included.
+
+=over 4
+
+This is also recursive configuration so it's important to be careful about what may be
+include in this path to avoid an inifinite loop. This is mostly useful for providing drop
+in backup lines without needing to add them to a central configuration files. We check the
+path is a directory and is readable, and will yell an error if it isn't.
+
+This does not recurse down directories but only parses the config in the specified
+directory. A regex can be supplied to filter the files in the directory to be included.
+
+
+Example: B<include_conf_dir /etc/rsnapshot.d>
+
+In this example any files ending in .conf in /etc/rsnapshot.d get included
+
+Example: B<include_conf_dir /opt/snapshot_confs .*\.snaps$>
+
+In this example a regex is applied so files ending in .snaps get included
 
 =back
 

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -622,24 +622,25 @@ sub parse_config_file {
 		if ($var eq 'include_conf_dir') {
 			my $conf_pat = '';
 			if (defined($value) && -d $value && -r $value) {
-			# Check for a regex filter, default to .conf if not specified
-			if (defined($value2)) {
-				$conf_pat = $value2;
-				} else {
-				$conf_pat = '.*\.conf$';
+				# Check for a regex filter, default to .conf if not specified
+				if (defined($value2)) {
+					$conf_pat = $value2;
+				}
+				else {
+					$conf_pat = '.*\.conf$';
 				}
 				opendir(CONF_DIR, $value) or die $!;
 				while (my $conf_file = readdir(CONF_DIR)) {
 					if ( -f "$value/$conf_file" && ($conf_file =~ m/$conf_pat/) ) {
-					parse_config_file("$value/$conf_file");
+						parse_config_file("$value/$conf_file");
 					}
 				}
 				closedir(CONF_DIR);
 				next;
-			} else {
+			}
+			else {
 				config_err($file_line_num, "$line - can't find or read directory '$value'");
 			}
-
 		}
 		# CONFIG_VERSION
 		if ($var eq 'config_version') {

--- a/t/include_conf/conf/bad_include_conf.conf.in
+++ b/t/include_conf/conf/bad_include_conf.conf.in
@@ -1,0 +1,8 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+include_conf	@TEST@/include_conf/conf/bad_include_file

--- a/t/include_conf/conf/bad_include_file.in
+++ b/t/include_conf/conf/bad_include_file.in
@@ -1,0 +1,1 @@
+backup    @TEST@/support/files/inc_conf_test/    include_conf_test/ bad test goes here

--- a/t/include_conf/conf/include_conf.conf.in
+++ b/t/include_conf/conf/include_conf.conf.in
@@ -1,0 +1,8 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+include_conf	@TEST@/include_conf/conf/include_file

--- a/t/include_conf/conf/include_file.in
+++ b/t/include_conf/conf/include_file.in
@@ -1,0 +1,1 @@
+backup	@TEST@/support/files/inc_conf_test/	include_conf_test/

--- a/t/include_conf/conf/no_include_conf.conf.in
+++ b/t/include_conf/conf/no_include_conf.conf.in
@@ -1,0 +1,8 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+backup	@TEST@/support/files/inc_conf_test/		no_include_file_test/

--- a/t/include_conf/include_conf.t.in
+++ b/t/include_conf/include_conf.t.in
@@ -1,0 +1,14 @@
+#!@PERL@
+use strict;
+use Test::More tests => 3; # pack here your amount of subtests
+use SysWrap;
+
+# This test checks that various uses of the include_conf option
+# correctly import the correct files, and only the correct files
+
+mkdir("@TEST@/support/files/inc_conf_test") unless -d "@TEST@/support/files/inc_conf_test";
+execute("cp @TEMP@/a/1 @TEMP@/a/2 @TEST@/support/files/inc_conf_test/");
+ok(0 == rsnapshot("-c @TEST@/include_conf/conf/no_include_conf.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/include_conf/conf/include_conf.conf hourly"));
+ok(1 == rsnapshot("-c @TEST@/include_conf/conf/bad_include_conf.conf hourly"));
+

--- a/t/include_conf_dir/conf/inc1.conf.d/inc1.conf.in
+++ b/t/include_conf_dir/conf/inc1.conf.d/inc1.conf.in
@@ -1,0 +1,9 @@
+
+
+backup	@TEST@/support/files/inc_dir_1-1/	dstdir1-1/
+
+
+
+
+
+

--- a/t/include_conf_dir/conf/inc1.conf.d/inc2.conf.in
+++ b/t/include_conf_dir/conf/inc1.conf.d/inc2.conf.in
@@ -1,0 +1,3 @@
+
+
+backup	@TEST@/support/files/inc_dir_1-2/	dstdir1-2/

--- a/t/include_conf_dir/conf/inc1.conf.d/inc3.conf.in
+++ b/t/include_conf_dir/conf/inc1.conf.d/inc3.conf.in
@@ -1,0 +1,3 @@
+
+
+backup	@TEST@/support/files/inc_dir_1-3/	dstdir1-3/

--- a/t/include_conf_dir/conf/inc2.conf.d/inc1.conf.in
+++ b/t/include_conf_dir/conf/inc2.conf.d/inc1.conf.in
@@ -1,0 +1,3 @@
+
+
+backup	@TEST@/support/files/inc_dir_2-1/	dstdir2-1/

--- a/t/include_conf_dir/conf/inc2.conf.d/inc2.conf.in
+++ b/t/include_conf_dir/conf/inc2.conf.d/inc2.conf.in
@@ -1,0 +1,3 @@
+
+
+backup	@TEST@/support/files/inc_dir_2-2/	dstdir2-2/

--- a/t/include_conf_dir/conf/inc2.conf.d/inc3.conf.in
+++ b/t/include_conf_dir/conf/inc2.conf.d/inc3.conf.in
@@ -1,0 +1,3 @@
+
+
+backup	@TEST@/support/files/inc_dir_2-3/	dstdir2-3/

--- a/t/include_conf_dir/conf/include.conf.d/bad_include_dir
+++ b/t/include_conf_dir/conf/include.conf.d/bad_include_dir
@@ -1,0 +1,1 @@
+backup /tmp	include_dir_test/ bad options go here to mess with the test

--- a/t/include_conf_dir/conf/include.conf.d/include_dir.conf.in
+++ b/t/include_conf_dir/conf/include.conf.d/include_dir.conf.in
@@ -1,0 +1,1 @@
+backup	@TEST@/support/files/inc_dir_test/	include_dir_test/

--- a/t/include_conf_dir/conf/include.inc.d/bad_include_dir
+++ b/t/include_conf_dir/conf/include.inc.d/bad_include_dir
@@ -1,0 +1,1 @@
+backup /tmp	include_dir_test/ bad options go here to mess with the test

--- a/t/include_conf_dir/conf/include.inc.d/include_dir.inc.in
+++ b/t/include_conf_dir/conf/include.inc.d/include_dir.inc.in
@@ -1,0 +1,1 @@
+backup	@TEST@/support/files/inc_dir_test/	include_dir_test/

--- a/t/include_conf_dir/conf/include_conf_dir.conf.in
+++ b/t/include_conf_dir/conf/include_conf_dir.conf.in
@@ -1,0 +1,9 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+
+include_conf_dir	@TEST@/include_conf_dir/conf/include.conf.d

--- a/t/include_conf_dir/conf/include_conf_dir_regex.conf.in
+++ b/t/include_conf_dir/conf/include_conf_dir_regex.conf.in
@@ -1,0 +1,9 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+
+include_conf_dir	@TEST@/include_conf_dir/conf/include.inc.d	.*\.inc$

--- a/t/include_conf_dir/conf/include_conf_dir_subdirs.conf.in
+++ b/t/include_conf_dir/conf/include_conf_dir_subdirs.conf.in
@@ -1,0 +1,8 @@
+
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+interval		hourly	6
+
+include_conf_dir	t/include_conf_dir/conf/inc1.conf.d
+include_conf_dir	t/include_conf_dir/conf/inc2.conf.d

--- a/t/include_conf_dir/include_conf_dir.t.in
+++ b/t/include_conf_dir/include_conf_dir.t.in
@@ -1,0 +1,13 @@
+#!@PERL@
+use strict;
+use Test::More tests => 2; # pack here your amount of subtests
+use SysWrap;
+
+# This test checks that various uses of the include_conf_dir option
+# correctly import the correct files, and only the correct files
+
+mkdir("@TEST@/support/files/inc_dir_test") unless -d "@TEST@/support/files/inc_dir_test";
+execute("cp @TEMP@/a/1 @TEMP@/a/2 @TEST@/support/files/inc_dir_test/");
+ok(0 == rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir_regex.conf hourly"));
+

--- a/t/include_conf_dir/include_conf_dir.t.in
+++ b/t/include_conf_dir/include_conf_dir.t.in
@@ -1,6 +1,6 @@
 #!@PERL@
 use strict;
-use Test::More tests => 2; # pack here your amount of subtests
+use Test::More tests => 3; # pack here your amount of subtests
 use SysWrap;
 
 # This test checks that various uses of the include_conf_dir option
@@ -10,4 +10,23 @@ mkdir("@TEST@/support/files/inc_dir_test") unless -d "@TEST@/support/files/inc_d
 execute("cp @TEMP@/a/1 @TEMP@/a/2 @TEST@/support/files/inc_dir_test/");
 ok(0 == rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir.conf hourly"));
 ok(0 == rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir_regex.conf hourly"));
+
+#
+# test multiple dirs
+#
+
+rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir_subdirs.conf hourly");
+
+my $cmd = "find "
+     . " @TEST@/support/snapshots/hourly.0/dstdir1-1/@TEST@/support/files/inc_dir_1-1 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir1-2/@TEST@/support/files/inc_dir_1-2 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir1-3/@TEST@/support/files/inc_dir_1-3 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir2-1/@TEST@/support/files/inc_dir_2-1 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir2-2/@TEST@/support/files/inc_dir_2-2 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir2-3/@TEST@/support/files/inc_dir_2-3 "
+     . " -type f | wc -l 2> /dev/null ";
+my $filesCopied = `$cmd`;
+
+ok( 6 == $filesCopied );
+execute("rm -rf @TEST@/support/snapshots/hourly.? 2> /dev/null");
 

--- a/t/support/files/inc_dir_1-1/dummydata1-1
+++ b/t/support/files/inc_dir_1-1/dummydata1-1
@@ -1,0 +1,1 @@
+dummydata1-1

--- a/t/support/files/inc_dir_1-2/dummydata1-2
+++ b/t/support/files/inc_dir_1-2/dummydata1-2
@@ -1,0 +1,1 @@
+dummydata1-2

--- a/t/support/files/inc_dir_1-3/dummydata1-3
+++ b/t/support/files/inc_dir_1-3/dummydata1-3
@@ -1,0 +1,1 @@
+dummydata1-3

--- a/t/support/files/inc_dir_2-1/dummydata2-1
+++ b/t/support/files/inc_dir_2-1/dummydata2-1
@@ -1,0 +1,1 @@
+dummydata2-1

--- a/t/support/files/inc_dir_2-2/dummydata2-2
+++ b/t/support/files/inc_dir_2-2/dummydata2-2
@@ -1,0 +1,1 @@
+dummydata2-2

--- a/t/support/files/inc_dir_2-3/dummydata2-3
+++ b/t/support/files/inc_dir_2-3/dummydata2-3
@@ -1,0 +1,1 @@
+dummydata2-3


### PR DESCRIPTION
PR151 - include_conf_dir

It was never released because of doubts whether perl pointers mix up with multiple subdirs. 

After some testing I noticed (my) perl did not mixup directory pointers with multiple include subdirs. So I just wrote a tester to prove it. 

This can be easily expanded to greater number of config subdirs if there are doubts.