### PR TITLE
Include_dir pull request, with testers and no dummyfiles in repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,3 @@ t/*.pm
 t/*/*.t
 t/*/conf/*.conf
 t/support/snapshots/
-t/support/files/inc_dir_test/
-t/support/files/inc_conf_test/
-t/include_conf/conf/bad_include_file
-t/include_conf/conf/include_file
-t/include_conf_dir/conf/include.d/include_dir.conf
-t/include_conf_dir/conf/include.inc.d/include_dir.inc
-t/include_conf_dir/conf/include.conf.d/include_dir.conf

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,10 @@ t/*.pm
 t/*/*.t
 t/*/conf/*.conf
 t/support/snapshots/
+t/support/files/inc_dir_test/
+t/support/files/inc_conf_test/
+t/include_conf/conf/bad_include_file
+t/include_conf/conf/include_file
+t/include_conf_dir/conf/include.d/include_dir.conf
+t/include_conf_dir/conf/include.inc.d/include_dir.inc
+t/include_conf_dir/conf/include.conf.d/include_dir.conf

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -622,24 +622,25 @@ sub parse_config_file {
 		if ($var eq 'include_conf_dir') {
 			my $conf_pat = '';
 			if (defined($value) && -d $value && -r $value) {
-			# Check for a regex filter, default to .conf if not specified
-			if (defined($value2)) {
-				$conf_pat = $value2;
-				} else {
-				$conf_pat = '.*\.conf$';
+				# Check for a regex filter, default to .conf if not specified
+				if (defined($value2)) {
+					$conf_pat = $value2;
+				}
+				else {
+					$conf_pat = '.*\.conf$';
 				}
 				opendir(CONF_DIR, $value) or die $!;
 				while (my $conf_file = readdir(CONF_DIR)) {
 					if ( -f "$value/$conf_file" && ($conf_file =~ m/$conf_pat/) ) {
-					parse_config_file("$value/$conf_file");
+						parse_config_file("$value/$conf_file");
 					}
 				}
 				closedir(CONF_DIR);
 				next;
-			} else {
+			}
+			else {
 				config_err($file_line_num, "$line - can't find or read directory '$value'");
 			}
-
 		}
 		# CONFIG_VERSION
 		if ($var eq 'config_version') {

--- a/t/SysWrap.pm.in
+++ b/t/SysWrap.pm.in
@@ -6,7 +6,7 @@ use Exporter 'import';
 
 our $VERSION = '1.0';
 
-our @EXPORT = qw(execute rsnapshot remove_snapshot_root rsnapshot_output);
+our @EXPORT = qw(execute rsnapshot remove_snapshot_root rsnapshot_output write_to_file);
 
 sub remove_snapshot_root {
 	my $args = shift(@_);
@@ -39,4 +39,12 @@ sub rsnapshot_output {
 	return `@PERL@ @CWD@/rsnapshot $args`;
 }
 
+sub write_to_file {
+	my $filename = $_[0];
+	my $content  = $_[1];
+
+	open(FH, '>', $filename) 
+		and print FH $content
+		and close(FH);
+}
 1;

--- a/t/include_conf/conf/bad_include_conf.conf.in
+++ b/t/include_conf/conf/bad_include_conf.conf.in
@@ -1,0 +1,8 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+include_conf	@TEST@/include_conf/conf/bad_include_file

--- a/t/include_conf/conf/bad_include_file.in
+++ b/t/include_conf/conf/bad_include_file.in
@@ -1,0 +1,1 @@
+backup    @TEST@/support/files/inc_conf_test/    include_conf_test/ bad test goes here

--- a/t/include_conf/conf/include_conf.conf.in
+++ b/t/include_conf/conf/include_conf.conf.in
@@ -1,0 +1,8 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+include_conf	@TEST@/include_conf/conf/include_file

--- a/t/include_conf/conf/include_file.in
+++ b/t/include_conf/conf/include_file.in
@@ -1,0 +1,1 @@
+backup	@TEST@/support/files/inc_conf_test/	include_conf_test/

--- a/t/include_conf/conf/no_include_conf.conf.in
+++ b/t/include_conf/conf/no_include_conf.conf.in
@@ -1,0 +1,8 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+backup	@TEST@/support/files/inc_conf_test/		no_include_file_test/

--- a/t/include_conf/include_conf.t.in
+++ b/t/include_conf/include_conf.t.in
@@ -1,0 +1,14 @@
+#!@PERL@
+use strict;
+use Test::More tests => 3; # pack here your amount of subtests
+use SysWrap;
+
+# This test checks that various uses of the include_conf option
+# correctly import the correct files, and only the correct files
+
+mkdir("@TEST@/support/files/inc_conf_test") unless -d "@TEST@/support/files/inc_conf_test";
+execute("cp @TEMP@/a/1 @TEMP@/a/2 @TEST@/support/files/inc_conf_test/");
+ok(0 == rsnapshot("-c @TEST@/include_conf/conf/no_include_conf.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/include_conf/conf/include_conf.conf hourly"));
+ok(1 == rsnapshot("-c @TEST@/include_conf/conf/bad_include_conf.conf hourly"));
+

--- a/t/include_conf_dir/conf/include.conf.d/bad_include_dir
+++ b/t/include_conf_dir/conf/include.conf.d/bad_include_dir
@@ -1,0 +1,1 @@
+backup /tmp	include_dir_test/ bad options go here to mess with the test

--- a/t/include_conf_dir/conf/include.conf.d/include_dir.conf.in
+++ b/t/include_conf_dir/conf/include.conf.d/include_dir.conf.in
@@ -1,0 +1,1 @@
+backup	@TEST@/support/files/inc_dir_test/	include_dir_test/

--- a/t/include_conf_dir/conf/include.inc.d/bad_include_dir
+++ b/t/include_conf_dir/conf/include.inc.d/bad_include_dir
@@ -1,0 +1,1 @@
+backup /tmp	include_dir_test/ bad options go here to mess with the test

--- a/t/include_conf_dir/conf/include.inc.d/include_dir.inc.in
+++ b/t/include_conf_dir/conf/include.inc.d/include_dir.inc.in
@@ -1,0 +1,1 @@
+backup	@TEST@/support/files/inc_dir_test/	include_dir_test/

--- a/t/include_conf_dir/conf/include_conf_dir.conf.in
+++ b/t/include_conf_dir/conf/include_conf_dir.conf.in
@@ -1,0 +1,9 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+
+include_conf_dir	@TEST@/include_conf_dir/conf/include.conf.d

--- a/t/include_conf_dir/conf/include_conf_dir_regex.conf.in
+++ b/t/include_conf_dir/conf/include_conf_dir_regex.conf.in
@@ -1,0 +1,9 @@
+config_version	1.2
+
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+
+interval		hourly	6
+
+
+include_conf_dir	@TEST@/include_conf_dir/conf/include.inc.d	.*\.inc$

--- a/t/include_conf_dir/conf/include_conf_dir_subdirs.conf.in
+++ b/t/include_conf_dir/conf/include_conf_dir_subdirs.conf.in
@@ -1,0 +1,8 @@
+
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+interval		hourly	6
+
+include_conf_dir	t/include_conf_dir/conf/inc1.conf.d
+include_conf_dir	t/include_conf_dir/conf/inc2.conf.d

--- a/t/include_conf_dir/include_conf_dir.t.in
+++ b/t/include_conf_dir/include_conf_dir.t.in
@@ -1,0 +1,13 @@
+#!@PERL@
+use strict;
+use Test::More tests => 2; # pack here your amount of subtests
+use SysWrap;
+
+# This test checks that various uses of the include_conf_dir option
+# correctly import the correct files, and only the correct files
+
+mkdir("@TEST@/support/files/inc_dir_test") unless -d "@TEST@/support/files/inc_dir_test";
+execute("cp @TEMP@/a/1 @TEMP@/a/2 @TEST@/support/files/inc_dir_test/");
+ok(0 == rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir_regex.conf hourly"));
+

--- a/t/include_conf_dir/include_conf_dir.t.in
+++ b/t/include_conf_dir/include_conf_dir.t.in
@@ -1,6 +1,6 @@
 #!@PERL@
 use strict;
-use Test::More tests => 2; # pack here your amount of subtests
+use Test::More tests => 3; # pack here your amount of subtests
 use SysWrap;
 
 # This test checks that various uses of the include_conf_dir option
@@ -10,4 +10,75 @@ mkdir("@TEST@/support/files/inc_dir_test") unless -d "@TEST@/support/files/inc_d
 execute("cp @TEMP@/a/1 @TEMP@/a/2 @TEST@/support/files/inc_dir_test/");
 ok(0 == rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir.conf hourly"));
 ok(0 == rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir_regex.conf hourly"));
+
+#
+# test multiple dirs
+#
+
+# Create dummydata dirs
+
+mkdir("@TEST@//support/files/inc_dir_1-1") unless -d "@TEST@/support/files/inc_dir_1-1";
+mkdir("@TEST@//support/files/inc_dir_1-2") unless -d "@TEST@/support/files/inc_dir_1-2";
+mkdir("@TEST@//support/files/inc_dir_1-3") unless -d "@TEST@/support/files/inc_dir_1-3";
+mkdir("@TEST@//support/files/inc_dir_2-1") unless -d "@TEST@/support/files/inc_dir_2-1";
+mkdir("@TEST@//support/files/inc_dir_2-2") unless -d "@TEST@/support/files/inc_dir_2-2";
+mkdir("@TEST@//support/files/inc_dir_2-3") unless -d "@TEST@/support/files/inc_dir_2-3";
+
+
+# Populate dummydata dirs
+
+my $filename; my $content;
+write_to_file( $filename="@TEST@//support/files/inc_dir_1-1/dummydata_1-1", $content="dummydata_1-1" ) unless -f "@TEST@//support/files/inc_dir_1-1/dummydata_1-1";
+write_to_file( $filename="@TEST@//support/files/inc_dir_1-2/dummydata_1-2", $content="dummydata_1-2" ) unless -f "@TEST@//support/files/inc_dir_1-2/dummydata_1-2";
+write_to_file( $filename="@TEST@//support/files/inc_dir_1-3/dummydata_1-3", $content="dummydata_1-3" ) unless -f "@TEST@//support/files/inc_dir_1-3/dummydata_1-3";
+write_to_file( $filename="@TEST@//support/files/inc_dir_2-1/dummydata_2-1", $content="dummydata_2-1" ) unless -f "@TEST@//support/files/inc_dir_2-1/dummydata_2-1";
+write_to_file( $filename="@TEST@//support/files/inc_dir_2-2/dummydata_2-2", $content="dummydata_2-2" ) unless -f "@TEST@//support/files/inc_dir_2-2/dummydata_2-2";
+write_to_file( $filename="@TEST@//support/files/inc_dir_2-3/dummydata_2-3", $content="dummydata_2-3" ) unless -f "@TEST@//support/files/inc_dir_2-3/dummydata_2-3";
+
+
+# Create config include dirs
+
+mkdir("@TEST@/include_conf_dir/conf/inc1.conf.d") unless -d "@TEST@/include_conf_dir/conf/inc1.conf.d";
+mkdir("@TEST@/include_conf_dir/conf/inc2.conf.d") unless -d "@TEST@/include_conf_dir/conf/inc2.conf.d";
+
+
+# Create config include files
+#
+# backup	@TEST@/support/files/inc_dir_1-1/	dstdir1-1
+#
+
+write_to_file( $filename="@TEST@/include_conf_dir/conf/inc1.conf.d/inc1.conf", $content="\nbackup	@TEST@/support/files/inc_dir_1-1/	dstdir1-1\n\n" ) unless -f "@TEST@/include_conf_dir/conf/inc1.conf.d/inc1.conf" ;
+write_to_file( $filename="@TEST@/include_conf_dir/conf/inc1.conf.d/inc2.conf", $content="\nbackup	@TEST@/support/files/inc_dir_1-2/	dstdir1-2\n\n" ) unless -f "@TEST@/include_conf_dir/conf/inc1.conf.d/inc2.conf" ;
+write_to_file( $filename="@TEST@/include_conf_dir/conf/inc1.conf.d/inc3.conf", $content="\nbackup	@TEST@/support/files/inc_dir_1-3/	dstdir1-3\n\n" ) unless -f "@TEST@/include_conf_dir/conf/inc1.conf.d/inc3.conf" ;
+write_to_file( $filename="@TEST@/include_conf_dir/conf/inc2.conf.d/inc1.conf", $content="\nbackup	@TEST@/support/files/inc_dir_2-1/	dstdir2-1\n\n" ) unless -f "@TEST@/include_conf_dir/conf/inc2.conf.d/inc1.conf" ;
+write_to_file( $filename="@TEST@/include_conf_dir/conf/inc2.conf.d/inc2.conf", $content="\nbackup	@TEST@/support/files/inc_dir_2-2/	dstdir2-2\n\n" ) unless -f "@TEST@/include_conf_dir/conf/inc2.conf.d/inc2.conf" ;
+write_to_file( $filename="@TEST@/include_conf_dir/conf/inc2.conf.d/inc3.conf", $content="\nbackup	@TEST@/support/files/inc_dir_2-3/	dstdir2-3\n\n" ) unless -f "@TEST@/include_conf_dir/conf/inc2.conf.d/inc3.conf" ;
+
+
+# run rsnapshot
+
+rsnapshot("-c @TEST@/include_conf_dir/conf/include_conf_dir_subdirs.conf hourly");
+
+
+# Count the amount of files in destination dirs
+
+my $cmd = "find "
+     . " @TEST@/support/snapshots/hourly.0/dstdir1-1/@TEST@/support/files/inc_dir_1-1 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir1-2/@TEST@/support/files/inc_dir_1-2 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir1-3/@TEST@/support/files/inc_dir_1-3 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir2-1/@TEST@/support/files/inc_dir_2-1 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir2-2/@TEST@/support/files/inc_dir_2-2 "
+     . " @TEST@/support/snapshots/hourly.0/dstdir2-3/@TEST@/support/files/inc_dir_2-3 "
+     . " -type f | wc -l 2> /dev/null ";
+
+my $filesCopied = `$cmd`;
+
+ok( 6 == $filesCopied );
+
+# cleanup
+
+execute("rm -rf @TEST@/support/snapshots/hourly.? @TEST@/support/files/inc_dir_?-? 2> /dev/null");
+
+
+
 


### PR DESCRIPTION
pr/151 was never merged as it was unclear whether perl would mixup file pointers with multiple config subdirs. After testing (my) perl didn't seem to mix up, so I just wrote testers to prove this all six config files get processed as should. it is easy to add more config subdirs if there are doubts. 

Tester now fully tests rsnapshot basic functionality. 