### PR TITLE
Minor bugfix: Check retval for termination by signal

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6091,12 +6091,11 @@ sub get_retval {
 		bail("get_retval() was passed $retval, a number is required");
 	}
 
-	# Check WIFSIGNALED and rerturn 128 + signo
-	if ($retval & 0x7f > 0) {
+	if ($retval & 0x7f) {
 		return (128 + ($retval & 0x7f));
 	}
 
-	return ($retval / 256);
+	return ($retval >> 8);
 }
 
 # accepts two file paths

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6091,10 +6091,10 @@ sub get_retval {
 		bail("get_retval() was passed $retval, a number is required");
 	}
 
-    # Check WIFSIGNALED and rerturn 128 + signo
-    if ($retval & 0x7f > 0) {
-        return (128 + ($retval & 0x7f));
-    }
+	# Check WIFSIGNALED and rerturn 128 + signo
+	if ($retval & 0x7f > 0) {
+		return (128 + ($retval & 0x7f));
+	}
 
 	return ($retval / 256);
 }

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6091,6 +6091,11 @@ sub get_retval {
 		bail("get_retval() was passed $retval, a number is required");
 	}
 
+    # Check WIFSIGNALED and rerturn 128 + signo
+    if ($retval & 0x7f > 0) {
+        return (128 + ($retval & 0x7f));
+    }
+
 	return ($retval / 256);
 }
 


### PR DESCRIPTION
This modifies `get_retval`. Under normal circumstances, the exit code is stored in the upper 8 bits of the 16 bit status variable, so it is correct to divide by 256.

However, if Rsync is terminated by a signal, it does not have a normal return code. Instead, the terminating signal is stored in the lower 7 bits and the expected return code (given by a shell) is 128 plus the signal number.

There are some cases where Rsync can be terminated by SIGSEGV, in which case the expected return code is 139. Instead, a floating point value is currently outputted:

```
ERROR: /usr/local/bin/rsync returned 0.54296875 while processing root@my.host.net:/
```

This patch fixes this by checking the equivalent of `WIFSIGNALED` and will instead return 128 + signo.