### PR TITLE
replace deprecated `interval` with `retain` in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ snapshots that are saved depends on the "interval" settings in
 
 For example:
 
-    interval	alpha		6
+    retain	alpha		6
 
 This means that every time `rsnapshot alpha` is run, it will make a
 new snapshot, rotate the old ones, and retain the most recent six


### PR DESCRIPTION
Readme still lists the deprecated `interval` key in the conf example. This PR replaces it with the current key `retain`