### PR TITLE
update readme with info on cross interval rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ intervals just rotate snapshots around.  Unless you have enabled
 pseudo-interval does the actual rsync, and all real intervals
 just rotate snapshots.
 
+Also remember that a higher interval will rotate the oldest snapshot of
+the interval one step lower as its newest snapshot. For instance if you set
+`daily` and `weekly` snapshots and set `daily` to keep 30 snapshots, the 
+newest snapshot for `weekly` will be the oldest (30 day old) `daily`
+snapshot after a rotation.
+
 For the full documentation, type `man rsnapshot` once it is installed. The
 [HOWTO](docs/HOWTOs/rsnapshot-HOWTO.en.html) also has a detailed overview of
 how to install and configure rsnapshot, and things like how to set it up so


### PR DESCRIPTION
As a new user with a very basic initial setup, this was the biggest gotcha for me. I thought it was prudent to clarify the cross interval rotation upfront.

The cronjobs and the interval settings are set separately and if out of sync, they can lead to very unexpected behavior like all weekly snapshots being many weeks old because the user didn't realize the retention setting for the lower interval had direct bearing on the higher interval snapshot rotation.