### PR TITLE
Fix validation of rsync_numtries = 0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -92,3 +92,6 @@ Matt McCutchen <matt@mattmccutchen.net>
 
 Imran Chaudhry <ichaudhry@gmail.com>
     - added -H to rsnapshot-diff
+
+Stefan Moch <stefanmoch@mail.de>
+    - Added test cases for rsync_numtries validation

--- a/AUTHORS
+++ b/AUTHORS
@@ -85,7 +85,7 @@ Ben Low <ben@bdlow.net>
     - Added support for Linux LVM snapshots
 
 David Grant <davidgrant@gmail.com>
-    - Added support for retrying rsync "rsync_numtries" number of times
+    - Added support for trying rsync "rsync_numtries" number of times
 
 Matt McCutchen <matt@mattmccutchen.net>
     - Wrote rsnapshot-copy (to copy snapshot roots using rsync --link-dest)
@@ -95,3 +95,5 @@ Imran Chaudhry <ichaudhry@gmail.com>
 
 Stefan Moch <stefanmoch@mail.de>
     - Added test cases for rsync_numtries validation
+    - Fix validation of rsync_numtries = 0, error message, configuration
+      example and related text.

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -1496,7 +1496,7 @@ sub parse_config_file {
 			}
 			if (!is_valid_rsync_numtries($value)) {
 				config_err($file_line_num,
-					"$line - \"$value\" is not a legal value for rsync_numtries, must be greater than or equal to 0");
+					"$line - \"$value\" is not a legal value for rsync_numtries, must be greater than or equal to 1");
 				next;
 			}
 
@@ -2788,7 +2788,7 @@ sub is_valid_rsync_numtries {
 	if (!defined($value)) { return (0); }
 
 	if ($value =~ m/^\d+$/) {
-		if (($value >= 0)) {
+		if (($value >= 1)) {
 			return (1);
 		}
 	}

--- a/rsnapshot.conf.default.in
+++ b/rsnapshot.conf.default.in
@@ -191,12 +191,12 @@ lockfile	/var/run/rsnapshot.pid
 #
 #use_lazy_deletes	0
 
-# Number of rsync re-tries. If you experience any network problems or
+# Number of rsync tries. If you experience any network problems or
 # network card issues that tend to cause ssh to fail with errors like
-# "Corrupted MAC on input", for example, set this to a non-zero value
-# to have the rsync operation re-tried.
+# "Corrupted MAC on input", for example, set this to a value > 1
+# to have the rsync operation re-tried. The default is 1.
 #
-#rsync_numtries 0
+#rsync_numtries 1
 
 # LVM parameters. Used to backup with creating lvm snapshot before backup
 # and removing it after. This should ensure consistency of data in some special

--- a/t/numtries/conf/numtries_fail_negative.conf.in
+++ b/t/numtries/conf/numtries_fail_negative.conf.in
@@ -1,0 +1,6 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+interval		hourly	6
+backup			@TEMP@/a/	localhost/
+rsync_numtries	-1

--- a/t/numtries/conf/numtries_fail_notanumber.conf.in
+++ b/t/numtries/conf/numtries_fail_notanumber.conf.in
@@ -1,0 +1,6 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+interval		hourly	6
+backup			@TEMP@/a/	localhost/
+rsync_numtries	notanumber	# needs to be a number

--- a/t/numtries/conf/numtries_fail_zero.conf.in
+++ b/t/numtries/conf/numtries_fail_zero.conf.in
@@ -1,0 +1,6 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+interval		hourly	6
+backup			@TEMP@/a/	localhost/
+rsync_numtries	0

--- a/t/numtries/conf/numtries_ok.conf.in
+++ b/t/numtries/conf/numtries_ok.conf.in
@@ -1,0 +1,6 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+interval		hourly	6
+backup			@TEMP@/a/	localhost/
+rsync_numtries	1

--- a/t/numtries/numtries.t.in
+++ b/t/numtries/numtries.t.in
@@ -1,7 +1,7 @@
 #!@PERL@
 
 use strict;
-use Test::More tests => 3;
+use Test::More tests => 4;
 use SysWrap;
 
 # rsync_numtries	1	-> okay
@@ -12,3 +12,6 @@ ok(0 != rsnapshot("-c @TEST@/numtries/conf/numtries_fail_negative.conf configtes
 
 # rsync_numtries	notanumber	-> not okay
 ok(0 != rsnapshot("-c @TEST@/numtries/conf/numtries_fail_notanumber.conf configtest"));
+
+# rsync_numtries	0	-> not okay
+ok(0 != rsnapshot("-c @TEST@/numtries/conf/numtries_fail_zero.conf configtest"));

--- a/t/numtries/numtries.t.in
+++ b/t/numtries/numtries.t.in
@@ -1,0 +1,14 @@
+#!@PERL@
+
+use strict;
+use Test::More tests => 3;
+use SysWrap;
+
+# rsync_numtries	1	-> okay
+ok(0 == rsnapshot("-c @TEST@/numtries/conf/numtries_ok.conf configtest"));
+
+# rsync_numtries	-1	-> not okay
+ok(0 != rsnapshot("-c @TEST@/numtries/conf/numtries_fail_negative.conf configtest"));
+
+# rsync_numtries	notanumber	-> not okay
+ok(0 != rsnapshot("-c @TEST@/numtries/conf/numtries_fail_notanumber.conf configtest"));


### PR DESCRIPTION
- Added test cases for rsync_numtries validation
- Fix validation of rsync_numtries = 0, error message, configuration
  example and related text.

Bug Report: https://github.com/rsnapshot/rsnapshot/issues/319