### PR TITLE
Rotate only if there will be a new <interval>.0 folder

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3356,6 +3356,13 @@ sub rotate_lowest_snapshots {
 
 	my $result;
 
+	# cancel if sync_first is enabled but .sync directory not existent
+	if (($config_vars{'sync_first'}) && (!-d "$config_vars{'snapshot_root'}/.sync/")) {
+		print_err("sync_first is enabled, but there is no .sync directory! Run rsnapshot with the ´sync´ command first. Refusing to rotate this level ($interval)", 1);
+		syslog_err("sync_first is enabled, but there is no .sync directory! Run rsnapshot with the ´sync´ command first. Refusing to rotate this level ($interval)");
+		bail();
+	}
+ 
 	# remove oldest directory
 	if ((-d "$config_vars{'snapshot_root'}/$interval.$interval_max") && ($interval_max > 0)) {
 
@@ -4656,6 +4663,14 @@ sub rotate_higher_interval {
 	my $prev_interval     = $$id_ref{'prev_interval'};
 	my $prev_interval_max = $$id_ref{'prev_interval_max'};
 
+	# here we check, if $prev_interval.$prev_interval_max exists and only do the rotation, if from that level can be pulled...
+	# otherwise bail. Maybe there should be an option for such new behaviour, too?
+	if (!-d "$config_vars{'snapshot_root'}/$prev_interval.$prev_interval_max") {
+		print_err("Did not find previous interval max ($config_vars{'snapshot_root'}/$prev_interval.$prev_interval_max), refusing to rotate this level ($interval)", 1);
+		syslog_err("Did not find previous interval max ($config_vars{'snapshot_root'}/$prev_interval.$prev_interval_max), refusing to rotate this level ($interval)");
+		bail();
+	}
+ 
 	# ROTATE DIRECTORIES
 	#
 	# delete the oldest one (if we're keeping more than one)

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3358,8 +3358,8 @@ sub rotate_lowest_snapshots {
 
 	# cancel if sync_first is enabled but .sync directory not existent
 	if (($config_vars{'sync_first'}) && (!-d "$config_vars{'snapshot_root'}/.sync/")) {
-		print_err("sync_first is enabled, but there is no .sync directory! Run rsnapshot with the ´sync´ command first. Refusing to rotate this level ($interval)", 1);
-		syslog_err("sync_first is enabled, but there is no .sync directory! Run rsnapshot with the ´sync´ command first. Refusing to rotate this level ($interval)");
+		print_err("sync_first is enabled but there is no .sync directory. Refusing to rotate this level ($interval). Run rsnapshot with the ´sync´ command first.", 1);
+		syslog_err("sync_first is enabled but there is no .sync directory. Refusing to rotate this level ($interval). Run rsnapshot with the ´sync´ command first.");
 		bail();
 	}
  

--- a/t/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf.in
+++ b/t/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf.in
@@ -1,0 +1,6 @@
+config_version	1.2
+snapshot_root	@SNAP@
+cmd_rsync		@RSYNC@
+interval		hourly	3
+interval		weekly	6
+backup			@TEMP@	localhost/

--- a/t/rotate_only_when_0_avail/rotate_only_when_0_avail.t.in
+++ b/t/rotate_only_when_0_avail/rotate_only_when_0_avail.t.in
@@ -1,0 +1,24 @@
+#!@PERL@
+
+use strict;
+use Test::More tests => 11;
+use SysWrap;
+
+remove_snapshot_root();
+ok(0 != rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));
+
+remove_snapshot_root();
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 != rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));
+
+remove_snapshot_root();
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 != rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));
+
+remove_snapshot_root();
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf hourly"));
+ok(0 == rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));
+ok(0 != rsnapshot("-c @TEST@/rotate_only_when_0_avail/conf/rotate_only_when_0_avail.conf weekly"));


### PR DESCRIPTION
A copy of https://github.com/rsnapshot/rsnapshot/pull/92, which seemed to be merged since 2015, but has never been. Re-opened as a new PR following [this advice](https://github.com/rsnapshot/rsnapshot/pull/34#issuecomment-1712594630).

With this bugfix, gaps like a missing .0 folder will be prevented.
See bug https://github.com/rsnapshot/rsnapshot/issues/18.

replace https://github.com/rsnapshot/rsnapshot/pull/34