### PR TITLE
strip redundant trailing slashes from backup dest

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3802,10 +3802,11 @@ sub rsync_backup_point {
 		# bp_ref{'dest'} and snapshot_root have already been validated, but these might be blank
 		if (defined($interval_link_dest) && defined($interval_num_link_dest)) {
 
+			# strip redundant trailing slashes
+			my $link_dest_val = "$config_vars{'snapshot_root'}/$interval_link_dest.$interval_num_link_dest/$$bp_ref{'dest'}";
+			$link_dest_val =~ s|/+$|/|;
 			# push link_dest arguments onto cmd stack
-			push(@rsync_long_args_stack,
-				"--link-dest=$config_vars{'snapshot_root'}/$interval_link_dest.$interval_num_link_dest/$$bp_ref{'dest'}"
-			);
+			push(@rsync_long_args_stack, "--link-dest=$link_dest_val");
 		}
 	}
 
@@ -3880,12 +3881,16 @@ sub rsync_backup_point {
 	push(@cmd_stack, "$src");
 	#
 	# dest
+	my $tmp_rsync_dest;
 	if ($interval eq 'sync') {
-		push(@cmd_stack, "$config_vars{'snapshot_root'}/.sync/$$bp_ref{'dest'}");
+		$tmp_rsync_dest = "$config_vars{'snapshot_root'}/.sync/$$bp_ref{'dest'}";
 	}
 	else {
-		push(@cmd_stack, "$config_vars{'snapshot_root'}/$interval.0/$$bp_ref{'dest'}");
+		$tmp_rsync_dest = "$config_vars{'snapshot_root'}/$interval.0/$$bp_ref{'dest'}";
 	}
+	# strip redundant trailing slashes
+	$tmp_rsync_dest =~ s|/+$|/|;
+	push(@cmd_stack, "$tmp_rsync_dest");
 	#
 	# END RSYNC COMMAND ASSEMBLY
 


### PR DESCRIPTION
After 2a2b302 (Fix regression in 262 (#283), 2021-06-08), the newly added normalize_dest_file_path_part() function changes a backup destination of './' or '.' to '/'.

This results in rsync_backup_point() adding a redundant trailing '/' to the rsync destination (and --link-dest argument, if enabled).

The redundant trailing slash isn't harmful, but it looks odd in the output and logs.  Remove it while generating the rsync command stack.