### PR TITLE
Fix rsync_numtries example in default config

### DIFF
--- a/rsnapshot.conf.default.in
+++ b/rsnapshot.conf.default.in
@@ -196,7 +196,7 @@ lockfile	/var/run/rsnapshot.pid
 # "Corrupted MAC on input", for example, set this to a value > 1
 # to have the rsync operation re-tried. The default is 1.
 #
-#rsync_numtries 1
+#rsync_numtries	1
 
 # LVM parameters. Used to backup with creating lvm snapshot before backup
 # and removing it after. This should ensure consistency of data in some special


### PR DESCRIPTION
Parameters and values must be separated by tabs in the rsnapshot config file.  When `rsync_numtries` was added in 7f0a553 (Added the ability to re-try the rsync operation ..., 2008-01-01), it mistakenly used a space.