### PR TITLE
Docs: Fix ASCII hyphens getting turned into en-dashes, other styling fixes

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -7147,7 +7147,7 @@ B<backup   /var/     localhost/   one_fs=1>
 =over 4
 
 This is the same as the other examples, but notice the fourth column.
-This is how you specify per-backup-point options to over-ride global
+This is how you specify per-backup-point options to override global
 settings.  This extra parameter can take several options, separated
 by B<commas>.
 

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6710,7 +6710,7 @@ interpreted.
 
 =back
 
-B<no_create_root>     If set to 1, rsnapshot won't create snapshot_root directory
+B<no_create_root>     If set to 1, rsnapshot won't create B<snapshot_root> directory
 
 B<cmd_rsync>          Full path to C<rsync> (required)
 
@@ -6956,10 +6956,10 @@ List of long arguments to pass to rsync.  The default values are
 This means that the directory structure in each backup point destination
 will match that in the backup point source.
 
-Quotes are permitted in rsync_long_args, eg C<--rsync-path='sudo /usr/bin/rsync'>.
+Quotes are permitted in B<rsync_long_args>, eg C<--rsync-path='sudo /usr/bin/rsync'>.
 You may use either single (') or double (") quotes, but nested quotes (including
 mixed nested quotes) are not permitted.  Similar quoting is also allowed in
-per-backup-point rsync_long_args.
+per-backup-point B<rsync_long_args>.
 
 =back
 
@@ -7209,7 +7209,7 @@ B<backup_exec      /bin/true/>
 
 =over 4
 
-backup_exec simply runs the command listed. The second argument is not
+B<backup_exec> simply runs the command listed. The second argument is not
 required and defaults to a value of 'optional'. It specifies the importance
 that the command return 0. Valid values are 'optional' and 'required'. If the
 command is specified as optional, a non-zero exit status from the command will
@@ -7626,7 +7626,7 @@ Current rsnapshot maintainer
 
 =back
 
-Carl Wilhelm Soderstrom B<(chrome@real-time.com)>
+Carl Wilhelm Soderstrom (B<chrome@real-time.com>)
 
 =over 4
 

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6648,7 +6648,7 @@ of cron jobs. It is possible, however, to run as any arbitrary user
 with an alternate configuration file.
 
 All important options are specified in a configuration file, which is
-located by default at B</etc/rsnapshot.conf>. An alternate file can be
+located by default at F</etc/rsnapshot.conf>. An alternate file can be
 specified on the command line. There are also additional options which
 can be passed on the command line.
 
@@ -6674,12 +6674,12 @@ B<-D> a firehose of diagnostic information
 
 =head1 CONFIGURATION
 
-B</etc/rsnapshot.conf> is the default configuration file. All parameters
-in this file must be separated by tabs. B</etc/rsnapshot.conf.default>
+F</etc/rsnapshot.conf> is the default configuration file. All parameters
+in this file must be separated by tabs. F</etc/rsnapshot.conf.default>
 can be used as a reference.
 
-It is recommended that you copy B</etc/rsnapshot.conf.default> to
-B</etc/rsnapshot.conf>, and then modify B</etc/rsnapshot.conf> to suit
+It is recommended that you copy F</etc/rsnapshot.conf.default> to
+F</etc/rsnapshot.conf>, and then modify F</etc/rsnapshot.conf> to suit
 your needs.
 
 Long lines may be split over several lines.  "Continuation" lines
@@ -7288,7 +7288,7 @@ also want to run it from the command line once or twice to get
 a feel for what it's doing.
 
 Here is an example crontab entry, assuming that backup levels B<alpha>,
-B<beta>, B<gamma> and B<delta> have been defined in B</etc/rsnapshot.conf>
+B<beta>, B<gamma> and B<delta> have been defined in F</etc/rsnapshot.conf>
 
 =over 4
 
@@ -7333,7 +7333,7 @@ your alpha snapshot will fail sometimes because the beta still has the lock.
 
 Remember that these are just the times that the program runs.
 To set the number of backups stored, set the B<retain> numbers in
-B</etc/rsnapshot.conf>
+F</etc/rsnapshot.conf>
 
 To check the disk space used by rsnapshot, you can call it with the "du" argument.
 
@@ -7483,8 +7483,8 @@ B<http://lists.sourceforge.net/lists/listinfo/rsnapshot-discuss>
 
 =head1 NOTES
 
-Make sure your /etc/rsnapshot.conf file has all elements separated by tabs.
-See /etc/rsnapshot.conf.default for a working example file.
+Make sure your F</etc/rsnapshot.conf> file has all elements separated by tabs.
+See F</etc/rsnapshot.conf.default> for a working example file.
 
 Make sure you put a trailing slash on the end of all directory references.
 If you don't, you may have extra directories created in your snapshots.
@@ -7500,7 +7500,7 @@ If you would like regular users to be able to restore their own backups,
 there are a number of ways this can be accomplished. One such scenario
 would be:
 
-Set B<snapshot_root> to B</.private/.snapshots> in B</etc/rsnapshot.conf>
+Set B<snapshot_root> to B</.private/.snapshots> in F</etc/rsnapshot.conf>
 
 Set the file permissions on these directories as follows:
 
@@ -7543,7 +7543,7 @@ backups will be restored in the same environment they came from. Without
 this option, restoring backups for multiple heterogeneous servers would
 be unmanageable. If you are archiving snapshots with GNU tar, you may
 want to use the --numeric-owner parameter. Also, keep a copy of the
-archived system's /etc/passwd and /etc/group files handy for the UID/GID
+archived system's F</etc/passwd> and F</etc/group> files handy for the UID/GID
 to name mapping.
 
 If you remove backup points in the config file, the previously archived

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6712,11 +6712,11 @@ interpreted.
 
 B<no_create_root>     If set to 1, rsnapshot won't create snapshot_root directory
 
-B<cmd_rsync>          Full path to rsync (required)
+B<cmd_rsync>          Full path to C<rsync> (required)
 
-B<cmd_ssh>            Full path to ssh (optional)
+B<cmd_ssh>            Full path to C<ssh> (optional)
 
-B<cmd_cp>             Full path to cp  (optional, but must be GNU version)
+B<cmd_cp>             Full path to C<cp> (optional, but must be GNU version)
 
 =over 4
 
@@ -6733,13 +6733,13 @@ files over (assuming there are any).
 
 =back
 
-B<cmd_rm>             Full path to rm (optional)
+B<cmd_rm>             Full path to C<rm> (optional)
 
-B<cmd_logger>         Full path to logger (optional, for syslog support)
+B<cmd_logger>         Full path to C<logger> (optional, for syslog support)
 
-B<cmd_du>             Full path to du (optional, for disk usage reports)
+B<cmd_du>             Full path to C<du> (optional, for disk usage reports)
 
-B<cmd_rsnapshot_diff> Full path to rsnapshot-diff (optional)
+B<cmd_rsnapshot_diff> Full path to C<rsnapshot-diff> (optional)
 
 B<cmd_preexec>
 
@@ -6956,7 +6956,7 @@ List of long arguments to pass to rsync.  The default values are
 This means that the directory structure in each backup point destination
 will match that in the backup point source.
 
-Quotes are permitted in rsync_long_args, eg --rsync-path="sudo /usr/bin/rsync".
+Quotes are permitted in rsync_long_args, eg C<--rsync-path='sudo /usr/bin/rsync'>.
 You may use either single (') or double (") quotes, but nested quotes (including
 mixed nested quotes) are not permitted.  Similar quoting is also allowed in
 per-backup-point rsync_long_args.
@@ -7186,15 +7186,11 @@ a destination directory for a backup_script that will clobber other backups.
 
 So in this example, say the backup_database.sh script simply runs a command like:
 
-=over 4
+    #!/bin/sh
 
-#!/bin/sh
+    mysqldump -uusername mydatabase > mydatabase.sql
 
-mysqldump -uusername mydatabase > mydatabase.sql
-
-chmod u=r,go= mydatabase.sql	# r-------- (0400)
-
-=back
+    chmod u=r,go= mydatabase.sql	# r-------- (0400)
 
 rsnapshot will take the generated "mydatabase.sql" file and move it into the
 <snapshot_root>/<retain>.0/db_backup/ directory. On subsequent runs,
@@ -7383,7 +7379,7 @@ B<rsnapshot diff /.snapshots/beta.0 /.snapshots/beta.1>
 
 =back
 
-This will call the rsnapshot-diff program, which will scan both directories
+This will call the C<rsnapshot-diff> program, which will scan both directories
 looking for differences (based on hard links).
 
 B<rsnapshot sync>
@@ -7508,13 +7504,9 @@ Set B<snapshot_root> to B</.private/.snapshots> in B</etc/rsnapshot.conf>
 
 Set the file permissions on these directories as follows:
 
-=over 4
+    drwx------    /.private
 
-drwx------    /.private
-
-drwxr-xr-x    /.private/.snapshots
-
-=back
+    drwxr-xr-x    /.private/.snapshots
 
 Export the /.private/.snapshots directory over read-only NFS, a read-only
 Samba share, etc.
@@ -7564,11 +7556,7 @@ For example, if you were previously backing up /home/ with a destination
 of localhost/, and alpha is your smallest backup level, you would need to do
 the following to reclaim that disk space:
 
-=over 4
-
-rm -rf <snapshot_root>/alpha.0/localhost/home/
-
-=back
+    rm -rf <snapshot_root>/alpha.0/localhost/home/
 
 Please note that the other snapshots previously made of /home/ will still
 be using that disk space, but since the files are flushed out of alpha.0/,
@@ -7603,7 +7591,7 @@ David Cantrell (B<david@cantrell.org.uk>)
 Previous maintainer of rsnapshot
 
 =item -
-Wrote the rsnapshot-diff utility
+Wrote the C<rsnapshot-diff> utility
 
 =item -
 Improved how use_lazy_deletes work so slow deletes don't screw up the next
@@ -7758,7 +7746,7 @@ Anthony Ettinger (B<apwebdesign@yahoo.com>)
 
 =over 4
 
-Wrote the utils/mysqlbackup.pl script
+Wrote the C<utils/mysqlbackup.pl> script
 
 =back
 
@@ -7766,7 +7754,7 @@ Sherman Boyd
 
 =over 4
 
-Wrote utils/random_file_verify.sh script
+Wrote C<utils/random_file_verify.sh> script
 
 =back
 
@@ -7774,7 +7762,7 @@ William Bear (B<bear@umn.edu>)
 
 =over 4
 
-Wrote the utils/rsnapreport.pl script (pretty summary of rsync stats)
+Wrote the C<utils/rsnapreport.pl> script (pretty summary of rsync stats)
 
 =back
 
@@ -7782,7 +7770,7 @@ Eric Anderson (B<anderson@centtech.com>)
 
 =over 4
 
-Improvements to utils/rsnapreport.pl.
+Improvements to C<utils/rsnapreport.pl>.
 
 =back
 

--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -6632,8 +6632,8 @@ B<rsnapshot> [B<-vtxqVD>] [B<-c> cfgfile] [command] [args]
 B<rsnapshot> is a filesystem snapshot utility. It can take incremental
 snapshots of local and remote filesystems for any number of machines.
 
-Local filesystem snapshots are handled with B<rsync(1)>. Secure remote
-connections are handled with rsync over B<ssh(1)>, while anonymous
+Local filesystem snapshots are handled with L<rsync(1)>. Secure remote
+connections are handled with rsync over L<ssh(1)>, while anonymous
 rsync connections simply use an rsync server. Both remote and local
 transfers depend on rsync.
 
@@ -7489,7 +7489,7 @@ See F</etc/rsnapshot.conf.default> for a working example file.
 Make sure you put a trailing slash on the end of all directory references.
 If you don't, you may have extra directories created in your snapshots.
 For more information on how the trailing slash is handled, see the
-B<rsync(1)> manpage.
+L<rsync(1)> manpage.
 
 Make sure to make the snapshot directory chmod 700 and owned by root
 (assuming backups are made by the root user). If the snapshot directory
@@ -7526,7 +7526,7 @@ configuration, or using an alternate shell.
 
 BE CAREFUL! If the private key is obtained by an attacker, they will
 have free run of all the systems involved. If you are unclear on how
-to do this, see B<ssh(1)>, B<sshd(1)>, and B<ssh-keygen(1)>.
+to do this, see L<ssh(1)>, L<sshd(1)>, and L<ssh-keygen(1)>.
 
 Backup scripts are run as the same user that rsnapshot is running as.
 Typically this is root. Make sure that all of your backup scripts are


### PR DESCRIPTION
When viewing man pages created by pod2man, it would insert a Unicode en-dash where an ASCII hyphen was necessary for copy-pasting code correctly.

Mostly I fixed this using `C<...>` and indenting literal paragraphs with spaces instead of using `=over` (which is for text not code).

Unfortunately using `C<...>` does add double quotes in the default manpage viewer. `pod2html` translates `C<...>` into `<code>...</code>`. I tried using `B<>` but the troff output for hyphen literals isn't affected by `B<...>` or `F<...>`; they would remain en-dashes when pod2man got through with it.

Other fixes:
- Grammatical issue: s/over-ride/override/
- Add some missing `B<...>` surrounding configuration options when mentioning them
- Use `F<...>` for filename references (e.g. `F</etc/rsnapshot.conf.default>` -- see `perldoc pod` for list of escapes)
- Use `L<...>` for links to man pages (e.g. `L<ssh(1)>`)