### PR TITLE
Docs: mention the behavior of "sync" cron job in case of "warnings"

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -7404,6 +7404,18 @@ B<30 23 1 * *         /usr/local/bin/rsnapshot delta>
 The sync operation simply runs rsync and all backup scripts. In this scenario, all
 calls simply rotate directories, even the lowest backup level.
 
+Please note, that the above "rsnapshot sync && rsnapshot alpha" command will
+skip rotation, whenever rsnapshot finishes its sync operation "with warnings"
+(e.g. some files vanished, while rsync was running).
+If you want to ensure rotation even in case of warnings, then the following
+command may be suitable for your cron job:
+
+=over 4
+
+B<0 */4 * * *         /usr/local/bin/rsnapshot sync || [ $? -eq 2 ] && /usr/local/bin/rsnapshot alpha>
+
+=back
+
 =back
 
 B<rsnapshot sync [dest]>


### PR DESCRIPTION
The recommended cron job command for `sync_first 1` behaves differently than the non-sync command recommendation:
* `sync_first 0`: "warnings" occurring during the rsync operation do not influence the following "rotate" operation
* `sync_first 1`: "warnings" during "rsnaphot sync" lead to an exit code value 2. The rotation is skipped (`rsnapshot sync && rsnapshot alpha`).

Now the man page mentions this difference in behavior and recommends an adjusted cron job, which preserves the non-sync behavior.

See #338