### PR TITLE
doc: with sync_first, don't skip cron'd rotation on warnings

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -7391,7 +7391,7 @@ the lowest, most frequent backup level, and right before. For example:
 
 =over 4
 
-B<0 */4 * * *         /usr/local/bin/rsnapshot sync && /usr/local/bin/rsnapshot alpha>
+B<0 */4 * * *         /usr/local/bin/rsnapshot sync; [ $? != 1 ] && /usr/local/bin/rsnapshot alpha>
 
 B<50 23 * * *         /usr/local/bin/rsnapshot beta>
 


### PR DESCRIPTION
The documented cron for sync_first will skip rotation on rsync warning (e.g. "xxx vanished during rsync operation").  
This is also a silent event in the default configuration.

This proposed changes only skip rotation on real error.