### PR TITLE
Notify when we retry an rsync operation

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -3903,6 +3903,10 @@ sub rsync_backup_point {
 			my $pid = open3($rsync_in, $rsync_out, undef, @cmd_stack)
 			  or die "Couldn't fork rsync: $!\n";
 
+			if ($tryCount > 0) {
+				print_msg("retrying, tryCount=".$tryCount, 3);
+			}
+
 			# add autoflush to get output by time and not at the end when rsync is finished
 			$rsync_out->autoflush();
 


### PR DESCRIPTION
Tapani Tarvainen requested this on the mailing list:

> I have a couple of clients with bad enough network connection
> that I need to set rsync_numtries = 3.
> 
> While that works, there's no easy way to see from logs how many
> tries have been necessary.
> 
> So, I would like to propose adding code for logging retries.
> 
> Here's a simple patch that does the trick:
> 
> *** /usr/bin/rsnapshot  2023-08-22 19:49:43.000000000 +0300
> --- rsnapshot   2024-07-21 17:01:42.159732440 +0300
> ***************
> *** 3897,3902 ****
> --- 3897,3906 ----
>         if (0 == $test) {
>                 while ($tryCount < $rsync_numtries && $result != 0) {
> 
> +                       if ($tryCount > 0) {
> +                               print_msg("retrying, tryCount=".$tryCount, 3);
> +                       }
> +
>                         # open rsync and capture STDOUT and STDERR
>                         # the 3rd argument is undefined, that STDERR gets mashed into STDOUT and we
>                         # don't have to care about getting both STREAMS together without mixing up time
> 
> That was created with rsnapshot 1.3.1 in Ubuntu Noble, but the relevant
> code looks identical in the latest version in Github. My apologies for
> not being well-versed with git so that I could create a pull request.

The patch is exactly as originally provided, except I moved the code to output the message a few lines further down to after the check to see if we can `fork()` an rsync - if that fails then preceding it with an "I'm about to retry" message seems superfluous.