### PR TITLE
Add new backup script for sqlite3 databases

### DIFF
--- a/rsnapshot.conf.default.in
+++ b/rsnapshot.conf.default.in
@@ -136,6 +136,11 @@ lockfile	/var/run/rsnapshot.pid
 #
 #rsync_short_args	-a
 #rsync_long_args	--delete --numeric-ids --relative --delete-excluded
+#
+# Note: there is an exception to every rule:
+#   There is a <tab> after `rsync_long_args` and before `--delete`.
+#   And a <space> after all of the other paramters.  Similar to:
+#   rsync_long_args<tab>--delete<space>--numeric-ids<space>--relative
 
 # ssh has no args passed by default, but you can specify some here.
 #

--- a/utils/README
+++ b/utils/README
@@ -77,3 +77,11 @@ sign_packages.sh
 ------------------------------------------------------------------------------
     The shell script used to automate package signing for releases.
 
+backup_sqlite.sh
+------------------------------------------------------------------------------
+    An example script to backup sqlite3 databases located in the `/var` 
+    directory.  This is to be invoked from rsnapshot using the "backup_script"
+    parameter. You will probably need to modify this for your setup.  Do NOT
+    replace `/var` with `/` otherwise find will locate all of your previous
+    database backups.
+

--- a/utils/README
+++ b/utils/README
@@ -46,6 +46,14 @@ backup_smb_share.sh
     rsnapshot using the "backup_script" parameter. This requires the Samba
     program. You will definitely need to modify this for your system.
 
+backup_sqlite.sh
+------------------------------------------------------------------------------
+    An example script to backup sqlite3 databases located in the `/var` 
+    directory.  This is to be invoked from rsnapshot using the "backup_script"
+    parameter. You will probably need to modify this for your setup.  Do NOT
+    replace `/var` with `/` otherwise find will locate all of your previous
+    database backups.
+
 debug_moving_files.sh
 ------------------------------------------------------------------------------
     Debug script for rsync. Moves files around, so you can try backing them
@@ -77,11 +85,4 @@ sign_packages.sh
 ------------------------------------------------------------------------------
     The shell script used to automate package signing for releases.
 
-backup_sqlite.sh
-------------------------------------------------------------------------------
-    An example script to backup sqlite3 databases located in the `/var` 
-    directory.  This is to be invoked from rsnapshot using the "backup_script"
-    parameter. You will probably need to modify this for your setup.  Do NOT
-    replace `/var` with `/` otherwise find will locate all of your previous
-    database backups.
 

--- a/utils/backup_sqlite.sh
+++ b/utils/backup_sqlite.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+##############################################################################
+# backup_sqlite.sh
+#
+# http://www.rsnapshot.org/
+#
+# This is a simple shell script to backup a sqlite database with rsnapshot.
+#
+# This script simply needs to dump a file into the current working directory.
+# rsnapshot handles everything else.
+#
+# The assumption is that this will be invoked from rsnapshot.
+# See:
+#	https://rsnapshot.org/rsnapshot/docs/docbook/rest.html#backup-script
+#
+#	Please remember that these backup scripts will be invoked as the user 
+#	running rsnapshot. Make sure your backup scripts are owned by root, 
+#	and not writable by anyone else. 
+#	If you fail to do this, anyone with write access to these backup scripts
+#	will be able to put commands in them that will be run as the root user. 
+#	If they are malicious, they could take over your server.
+#
+#		chown root:root backup_sqlite.sh
+#		chmod 700 backup_sqlite.sh
+#
+##############################################################################
+
+umask 0077
+
+# backup the database
+/bin/find /var -type f -iname "*.db" -exec bash -c '/usr/bin/file {} | /bin/grep -q "SQLite 3" && /usr/bin/sqlite3 {} ".backup $(/usr/bin/basename {})" ' \;
+
+# make the backup readable only by root
+/bin/chmod 600 *.db
+
+exit


### PR DESCRIPTION
backup_sqlite.sh will backup sqlite3 databases to the current working directory.

recreated from:
https://github.com/rsnapshot/rsnapshot/pull/326
