### PR TITLE
Add a Github publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: build
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-[a-z0-9]+"
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: configure
+        run: |
+          ./autogen.sh
+          ./configure
+      - name: build
+        run: |
+          make
+          make test
+          make tar
+      - name: Store the build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: dist/
+  github-release:
+    name: Sign assets with Sigstore and upload them to GitHub Release
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+          path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          --repo '${{ github.repository }}'
+          --notes ""
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload
+          '${{ github.ref_name }}' dist/**
+          --repo '${{ github.repository }}'

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,44 +36,35 @@ clean:
 	rm -f t/support/files/a/{1,2}
 	rm -rf t/support/snapshots/*.*
 
+tar: dist/rsnapshot-$(VERSION).tar.gz
 
-tar: rsnapshot-$(VERSION).tar.gz
-	@touch tar
-
-rsnapshot-$(VERSION).tar.gz: $(man_MANS) Makefile $(bin_SCRIPTS) $(sysconf_DATA)
+dist/rsnapshot-$(VERSION).tar.gz: $(man_MANS) Makefile $(bin_SCRIPTS) $(sysconf_DATA)
 	@echo building tar file
-	mkdir rsnapshot-$(VERSION)/
-
+	mkdir -p dist/rsnapshot-$(VERSION)/
 	@# core files
 	cp -a AUTHORS ChangeLog COPYING INSTALL.md Makefile.am README.md \
  		rsnapshot.conf.default.in rsnapshot-diff.pl rsnapshot-program.pl \
- 		rsnapshot-$(VERSION)
-
+ 		dist/rsnapshot-$(VERSION)
 	@# autoconf files
 	cp -a configure.ac Makefile.am \
 		aclocal.m4 autom4te.cache configure install-sh Makefile.in missing \
-		rsnapshot-$(VERSION)/
-
+		dist/rsnapshot-$(VERSION)/
 	@# documentation files
 	cp -a docs \
-		rsnapshot-$(VERSION)/
-
+		dist/rsnapshot-$(VERSION)/
 	@# utils
 	cp -a utils/ \
-		rsnapshot-$(VERSION)/
-
+		dist/rsnapshot-$(VERSION)/
 	@# testsuite
 	cp -a t/ \
-	rsnapshot-$(VERSION)/
-
+		dist/rsnapshot-$(VERSION)/
 	@# remove git-files
-	find rsnapshot-$(VERSION)/ -depth -name .gitignore -exec rm -rf {} \;
-
+	find dist/rsnapshot-$(VERSION)/ -depth -name .gitignore -exec rm -rf {} \;
 	@# change ownership to root, and delete build dir
-	fakeroot chown -R root:root rsnapshot-$(VERSION)/
-	rm -f rsnapshot-$(VERSION).tar.gz
-	tar czf rsnapshot-$(VERSION).tar.gz rsnapshot-$(VERSION)/
-	rm -rf rsnapshot-$(VERSION)/
+	fakeroot chown -R root:root dist/rsnapshot-$(VERSION)/
+	rm -f dist/rsnapshot-$(VERSION).tar.gz
+	tar czf dist/rsnapshot-$(VERSION).tar.gz dist/rsnapshot-$(VERSION)/
+	rm -rf dist/rsnapshot-$(VERSION)/
 	@echo
 
 # If you lack GNU make, you could use "test_cases = t/*.t" as an approximation.


### PR DESCRIPTION
Add a Github publish workflow to automate publishing of release to Github (rsnapshot.org is a WIP). Maintainer just needs to update Changelog then push a tag.

Also builds a .deb file. Not meant to replace debian package but just in case Debian package maintainer disappears again. Unfortunately debian package build requires a debian/ directory with a bunch of cruft in it. I cut it back to the bare minimum and does not include a change log because we already have a changelog and maintaining the debian changelog in addition is annoying. Also means the .deb is unsigned because signing would require keep a GPG key in secrets and don't want to do that. Instead release assets are signed with Sigstore signature. Ref #363 