### PR TITLE
guard against --relative being in rsync_opts

### DIFF
--- a/utils/rsnapshot-copy
+++ b/utils/rsnapshot-copy
@@ -64,7 +64,7 @@ do_cmd rsync "${rsync_opts[@]}" --exclude=* "$src/" "$dest/"
 # Obtain a list of snapshot names in newest to oldest order.
 # List the src -> filter to `2008/04/09T17:59:43 alpha.0' format
 # -> sort newest to oldest -> read each line, ignoring the time.
-rsync "${rsync_opts[@]}" --list-only --no-r -d --no-l "$src/" \
+rsync "${rsync_opts[@]}" --list-only --no-R --no-r -d --no-l "$src/" \
 	| sed -nre 's,^d[^ ]+ +[^ ]+ (..../../..) (..:..:..) (.*\.[0-9]+)$,\1T\2 \3,p' \
 	| LC_ALL=C sort -r --key=1,1 | {
 	# --link-dest option to use, if any


### PR DESCRIPTION
Today, while working on migrating a server, I tried to use `rsnapshot-copy` and encountered an unexpected problem.

It turned out that if `--relative` is included in the rsync options supplied by the user, then the result is a directory listing that includes multiple path components. For example, after running `rsnapshot-copy` with `-a --numeric-ids --relative` as rsync options, the rsync command following the comment "Obtain a list of snapshot names in newest to oldest order." ends up looking like this: `rsync -a --numeric-ids --relative --list-only --no-r -d --no-l 192.168.179.43:/var/cache/rsnapshot/` and produces this output:

```
drwxr-xr-x          4,096 2017/12/15 12:22:17 var
drwxr-xr-x          4,096 2024/10/13 16:27:46 var/cache
drwx------          4,096 2025/07/15 12:00:12 var/cache/rsnapshot
drwxr-xr-x          4,096 2025/07/14 04:00:12 var/cache/rsnapshot/daily.0
drwxr-xr-x          4,096 2025/07/13 04:00:14 var/cache/rsnapshot/daily.1
drwxr-xr-x          4,096 2025/07/12 04:00:15 var/cache/rsnapshot/daily.2
drwxr-xr-x          4,096 2025/07/11 04:00:12 var/cache/rsnapshot/daily.3
drwxr-xr-x          4,096 2025/07/10 04:00:12 var/cache/rsnapshot/daily.4
drwxr-xr-x          4,096 2025/07/09 04:00:12 var/cache/rsnapshot/daily.5
drwxr-xr-x          4,096 2025/07/08 04:00:11 var/cache/rsnapshot/daily.6
drwxr-xr-x          4,096 2025/07/15 12:00:32 var/cache/rsnapshot/hourly.0
drwxr-xr-x          4,096 2025/07/15 08:00:15 var/cache/rsnapshot/hourly.1
drwxr-xr-x          4,096 2025/07/15 04:00:13 var/cache/rsnapshot/hourly.2
drwxr-xr-x          4,096 2025/07/15 00:00:17 var/cache/rsnapshot/hourly.3
drwxr-xr-x          4,096 2025/07/14 20:00:45 var/cache/rsnapshot/hourly.4
drwxr-xr-x          4,096 2025/07/14 16:00:15 var/cache/rsnapshot/hourly.5
drwx------         16,384 2022/05/03 17:05:03 var/cache/rsnapshot/lost+found
drwxr-xr-x          4,096 2025/06/01 04:00:15 var/cache/rsnapshot/monthly.0
drwxr-xr-x          4,096 2025/04/27 04:00:12 var/cache/rsnapshot/monthly.1
drwxr-xr-x          4,096 2025/03/30 04:00:14 var/cache/rsnapshot/monthly.2
drwxr-xr-x          4,096 2025/07/06 04:00:13 var/cache/rsnapshot/weekly.0
drwxr-xr-x          4,096 2025/06/29 04:00:12 var/cache/rsnapshot/weekly.1
drwxr-xr-x          4,096 2025/06/22 04:00:12 var/cache/rsnapshot/weekly.2
drwxr-xr-x          4,096 2025/06/15 04:00:13 var/cache/rsnapshot/weekly.3
```

This results in paths like `/var/cache/rsnapshot/var/cache/rsnapshot/hourly.0` in the commands for copying the individual snapshots.

After making the modification proposed in this PR, the command looks like this: `rsync -a --numeric-ids --relative --list-only --no-R --no-r -d --no-l 192.168.179.43:/var/cache/rsnapshot/` and produces this output:

```
drwx------          4,096 2025/07/15 12:00:12 .
drwxr-xr-x          4,096 2025/07/14 04:00:12 daily.0
drwxr-xr-x          4,096 2025/07/13 04:00:14 daily.1
drwxr-xr-x          4,096 2025/07/12 04:00:15 daily.2
drwxr-xr-x          4,096 2025/07/11 04:00:12 daily.3
drwxr-xr-x          4,096 2025/07/10 04:00:12 daily.4
drwxr-xr-x          4,096 2025/07/09 04:00:12 daily.5
drwxr-xr-x          4,096 2025/07/08 04:00:11 daily.6
drwxr-xr-x          4,096 2025/07/15 12:00:32 hourly.0
drwxr-xr-x          4,096 2025/07/15 08:00:15 hourly.1
drwxr-xr-x          4,096 2025/07/15 04:00:13 hourly.2
drwxr-xr-x          4,096 2025/07/15 00:00:17 hourly.3
drwxr-xr-x          4,096 2025/07/14 20:00:45 hourly.4
drwxr-xr-x          4,096 2025/07/14 16:00:15 hourly.5
drwx------         16,384 2022/05/03 17:05:03 lost+found
drwxr-xr-x          4,096 2025/06/01 04:00:15 monthly.0
drwxr-xr-x          4,096 2025/04/27 04:00:12 monthly.1
drwxr-xr-x          4,096 2025/03/30 04:00:14 monthly.2
drwxr-xr-x          4,096 2025/07/06 04:00:13 weekly.0
drwxr-xr-x          4,096 2025/06/29 04:00:12 weekly.1
drwxr-xr-x          4,096 2025/06/22 04:00:12 weekly.2
drwxr-xr-x          4,096 2025/06/15 04:00:13 weekly.3
```

This is the same output that is produced when the `--relative` option is absent, and this appears to be the output format that the sed command is expecting to encounter.

I confirmed that after this modification invoking `rsnapshot-copy` with `--relative` among the rsync options did not cause the execution to fail.