### PR TITLE
Log stderr output of gnu_cp_al command

### DIFF
--- a/rsnapshot-program.pl
+++ b/rsnapshot-program.pl
@@ -4865,29 +4865,6 @@ sub cp_al {
 	return ($result);
 }
 
-# This is to test whether cp -al seems to work in a simple case
-# return 0  if cp -al succeeds
-# return 1  if cp -al fails
-# return -1 if something else failed - test inconclusive
-sub test_cp_al {
-	my $s = "$config_vars{'snapshot_root'}/cp_al1";
-	my $d = "$config_vars{'snapshot_root'}/cp_al2";
-	my $result;
-
-	-d $s || mkdir($s) || return (-1);
-	open(TT1, ">>$s/tt1") || return (-1);
-	close(TT1) || return (-1);
-	$result = system($config_vars{'cmd_cp'}, '-al', "$s", "$d");
-	if ($result != 0) {
-		return (1);
-	}
-	unlink("$d/tt1");
-	unlink("$s/tt1");
-	rmdir($d);
-	rmdir($s);
-	return (0);
-}
-
 # this is a wrapper to call the GNU version of "cp"
 # it might fail in mysterious ways if you have a different version of "cp"
 #
@@ -4933,9 +4910,6 @@ sub gnu_cp_al {
 	if ($result != 0) {
 		$status = $result >> 8;
 		print_err("$config_vars{'cmd_cp'} -al $src $dest failed (result $result, exit status $status): $errstr", 2);
-		if (test_cp_al() > 0) {
-			print_err("Perhaps your cp does not support -al options?", 2);
-		}
 		return (0);
 	}
 


### PR DESCRIPTION
If cp in gnu_cp_al() fails we end up with error that tells us nothing useful logged into cmd_logger

````
[2025-07-21T02:05:49] /bin/cp -al /mnt/example/daily.0 /mnt/example/daily.1
[2025-07-21T12:26:10] /usr/bin/rsnapshot -c /etc/agrsnapshot/example.conf daily: ERROR: /bin/cp -al /mnt/example/daily.0 /mnt/example/daily.1 failed (result 256, exit status 1).
[2025-07-21T12:26:10] /usr/bin/rsnapshot -c /etc/agrsnapshot/example.conf daily: ERROR: Error! cp_al("/mnt/example/daily.0/", "/mnt/example/daily.1/")
[2025-07-21T12:26:10] /usr/bin/logger -p user.err -t rsnapshot[2706374] /usr/bin/rsnapshot -c /etc/agrsnapshot/example.conf daily: ERROR: Error! cp_al("/mnt/example/daily.0/", "/mnt/example/daily.1/")                     [2025-07-21T12:26:10] rm -f /var/run/example.pid
````

where the real error was

````
/bin/cp: cannot stat <here very, very long path> : File name too long
````

Change that so stderr output now gets nicely logged.


There is also a second (optional) commit which drops test_cp_al() as now error message from cp will be directly visible to the user. 