### PR TITLE
Create native packages for rsnapshot.

### DIFF
--- a/contrib/epm-pkg/.gitignore
+++ b/contrib/epm-pkg/.gitignore
@@ -1,0 +1,5 @@
+ver.mak
+ver.epm
+ver.env
+epm.list
+*~

--- a/contrib/epm-pkg/Makefile
+++ b/contrib/epm-pkg/Makefile
@@ -1,0 +1,117 @@
+# -*- mode: makefile; -*-
+# contrib/epm-pkg/Makefile.pkg
+# Build packages with epm program.
+# All the config files are in: contrib/epm-pkg/
+
+# To use always reference the contrib/epm-pkg/Makefile.pkg. See alias.
+# make -f contrib/epm-pkg/Makefile.pkg TARGET
+
+
+# --------------------
+# Macros
+SHELL=/bin/bash
+mRsyncOpt=-azP
+mPrefix=dist/usr/local
+mShare=$(mPrefix)/share/doc/rsnapshot
+
+include ver.mak
+
+# --------------------
+# Manual Targets
+
+# 1
+help :
+	@echo -e "\nInitialize"
+	@echo -e '\tpkg config\n'
+	@echo -e "Build the pseudo root dist/"
+	@echo -e "\tpkg build\n"
+	@echo -e "Create the package. Put it in pkg/"
+	@echo -e "\tpkg package"
+
+# 2
+config : check-deps ../../configure ver.mak
+	if [ "$$(whoami)" = 'root' ]; then exit 1; fi
+	@echo -e '\nNow type "make build"'
+
+# 3
+build ../../dist/usr/local/bin/rsnapshot : ../../configure ../../dist ver.env
+	if [ "$$(whoami)" = 'root' ]; then exit 1; fi
+	-rm -rf ../../dist/*
+	cd ../..; make
+	cd ../..; make install
+	cd ../..; make html
+	-cd ../..; mkdir -p $(mShare)
+	cd ../..; cp -r docs/* $(mShare)
+	cd ../..; cp COPYING $(mShare)/LICENSE
+	cd ../..; cp README.md $(mShare)
+	cd ../..; cp rsnapshot.html $(mShare)
+	grep PRETTY_NAME /etc/lsb-release >../../$(mShare)/build-os
+	uname -a >>../../$(mShare)/build-os
+	find ../../dist -type d -exec chmod a+rx {} \;
+	find ../../dist -type f -exec chmod a+r {} \;
+	cd ../..; mkepmlist -u root -g root --prefix / dist | patch-epm-list -f ./contrib/epm-pkg/epm.patch >contrib/epm-pkg/epm.list
+	@echo -e '\nNow type "make test"'
+
+# 4
+test :
+	cd ../..; make test
+	@echo -e '\nIf OK type "sudo make package"'
+
+# 5
+package : ../../dist/usr/local/bin/rsnapshot ../../pkg ver.epm
+	if [ "$$(whoami)" != 'root' ]; then exit 1; fi
+	-rm -f ../../pkg/*
+	cd ../..; epm -v -f native --output-dir pkg $(ProdName) contrib/epm-pkg/ver.epm
+	cd ../..; epm -v -f portable --output-dir pkg -m $(ProdOSDist)-$(ProdArch) $(ProdName) contrib/epm-pkg/ver.epm
+	chown -R $$SUDO_USER:$$SUDO_USER ../../*
+	@echo -e '\nIf OK type "make release"'
+
+# 6
+release : save ver.env
+	if [ "$$(whoami)" = 'root' ]; then exit 1; fi
+	+. ./ver.env; echo ssh $$ProdRelServer mkdir -p $$ProdRelDir/$$ProdOS
+	. ./ver.env; ssh $$ProdRelServer mkdir -p $$ProdRelDir/$$ProdOS
+	+. ./ver.env; echo rsync -P ../../pkg/* $$ProdRelServer:$$ProdRelDir/$$ProdOS
+	. ./ver.env; rsync -P ../../pkg/* $$ProdRelServer:$$ProdRelDir/$$ProdOS
+
+# 7
+save :
+	if [ "$$(whoami)" = 'root' ]; then exit 1; fi
+	git pull origin develop
+	-git commit -am Updated
+	-git push origin develop
+	@echo -e '\nIf done type "make dist-clean"'
+
+# 8
+dist-clean : clean
+	-cd ../..; make clean
+	-cd ../..; rm -rf dist pkg configure rsnapshot.html
+	-rm  epm.list ver.mak ver.env ver.epm
+
+clean :
+	-find . -type f -name '*~' -exec rm {} \;
+
+# --------------------
+# Rules
+
+check-deps :
+	command -v aclocal >/dev/null
+	command -v autoreconf >/dev/null
+	command -v epm >/dev/null
+	command -v git >/dev/null
+	command -v git >/dev/null
+	command -v mkepmlist >/dev/null
+	command -v mkver.pl >/dev/null
+	command -v patch-epm-list >/dev/null
+	command -v perl >/dev/null
+	command -v rsync >/dev/null
+
+../../configure : ../../autogen.sh
+	cd ../..; ./autogen.sh
+	cd ../..; ./configure --prefix=$$PWD/$(mPrefix)
+
+../../dist ../../pkg :
+	-mkdir $@
+
+ver.mak ver.env ver.epm : ver.sh
+	export RELEASE=1; mkver.pl -e 'mak env epm' -d $?

--- a/contrib/epm-pkg/Makefile
+++ b/contrib/epm-pkg/Makefile
@@ -1,11 +1,7 @@
 # -*- mode: makefile; -*-
-# contrib/epm-pkg/Makefile.pkg
+# contrib/epm-pkg/Makefile
 # Build packages with epm program.
 # All the config files are in: contrib/epm-pkg/
-
-# To use always reference the contrib/epm-pkg/Makefile.pkg. See alias.
-# make -f contrib/epm-pkg/Makefile.pkg TARGET
-
 
 # --------------------
 # Macros
@@ -22,16 +18,16 @@ include ver.mak
 # 1
 help :
 	@echo -e "\nInitialize"
-	@echo -e '\tpkg config\n'
+	@echo -e '\tmake config\n'
 	@echo -e "Build the pseudo root dist/"
-	@echo -e "\tpkg build\n"
+	@echo -e "\tmake build\n"
 	@echo -e "Create the package. Put it in pkg/"
-	@echo -e "\tpkg package"
+	@echo -e "\tmake package"
 
 # 2
 config : check-deps ../../configure ver.mak
 	if [ "$$(whoami)" = 'root' ]; then exit 1; fi
-	@echo -e '\nNow type "make build"'
+	@echo -e '\nNow run "make build"'
 
 # 3
 build ../../dist/usr/local/bin/rsnapshot : ../../configure ../../dist ver.env
@@ -50,12 +46,12 @@ build ../../dist/usr/local/bin/rsnapshot : ../../configure ../../dist ver.env
 	find ../../dist -type d -exec chmod a+rx {} \;
 	find ../../dist -type f -exec chmod a+r {} \;
 	cd ../..; mkepmlist -u root -g root --prefix / dist | patch-epm-list -f ./contrib/epm-pkg/epm.patch >contrib/epm-pkg/epm.list
-	@echo -e '\nNow type "make test"'
+	@echo -e '\nNow run "make test"'
 
 # 4
 test :
 	cd ../..; make test
-	@echo -e '\nIf OK type "sudo make package"'
+	@echo -e '\nIf OK run "sudo make package"'
 
 # 5
 package : ../../dist/usr/local/bin/rsnapshot ../../pkg ver.epm
@@ -64,7 +60,7 @@ package : ../../dist/usr/local/bin/rsnapshot ../../pkg ver.epm
 	cd ../..; epm -v -f native --output-dir pkg $(ProdName) contrib/epm-pkg/ver.epm
 	cd ../..; epm -v -f portable --output-dir pkg -m $(ProdOSDist)-$(ProdArch) $(ProdName) contrib/epm-pkg/ver.epm
 	chown -R $$SUDO_USER:$$SUDO_USER ../../*
-	@echo -e '\nIf OK type "make release"'
+	@echo -e '\nIf OK run "make release"'
 
 # 6
 release : save ver.env

--- a/contrib/epm-pkg/README-pkg.org
+++ b/contrib/epm-pkg/README-pkg.org
@@ -4,7 +4,21 @@
   "portable" packge is also build. See the EPM manual for help with
   building the different OS packages. Between EPM, the Makefile, and
   ver.sh, most any *nix OS distribution package can be built.
-- (Note: flatpak, appimage, and snap are not supported by EPM.)
+** Supported OS packages
++ AIX software packages ("installp")
++ AT&T software packages ("pkgadd"), used by Solaris and others
++ BSD packages ("pkg_create")
++ Compaq Tru64 UNIX ("setld")
++ Debian Package Manager ("dpkg")
++ HP-UX software packages ("swinstall")
++ IRIX software manager ("inst", "swmgr", or "tardist")
++ macOS software packages ("name.pkg")
++ Red Hat Package Manager ("rpm")
++ Slackware software packages ("name.tgz")
++ Portable (installation and removal scripts with tar files)
+
+- flatpak, appimage, and snap are not supported by EPM.
+
 ** Setup
 + Install the dependencies.
 + Modify ver.sh as needed. Directions are in the comments.
@@ -38,7 +52,12 @@
   + Manually check epm.list file
 + make test - run the rsnapshot tests
   + Verify the tests ran OK
++ edit 
+  + increment the ProdBuild var in ver.sh
+  + create the $ProdOSDist.require file for your OS (see ver.env)
 + make package - build the native and portable packages
+  + to build "native" packages, you need to be in the OS you are
+    making the package for.
 + make release - copy package files to a "release" server
 + make dist-clean - remove all generated files
 

--- a/contrib/epm-pkg/README-pkg.org
+++ b/contrib/epm-pkg/README-pkg.org
@@ -1,0 +1,64 @@
+* Build rsnapshot packages with EPM
+- The Makefile and files in this directory will build "native"
+  packages for the rsnapshot program. A mostly OS independent
+  "portable" packge is also build. See the EPM manual for help with
+  building the different OS packages. Between EPM, the Makefile, and
+  ver.sh, most any *nix OS distribution package can be built.
+- (Note: flatpak, appimage, and snap are not supported by EPM.)
+** Setup
++ Install the dependencies.
++ Modify ver.sh as needed. Directions are in the comments.
+** ver.sh - define the package's meta-data.
++ The meta-data defines things like the product's name, version, build
+  user, OS, OS version, release server, release dirs, etc.
++ mkver.pl will convert the variables to the syntax used by various
+  programs: make, bash, perl, java, epm, xml
+
+** Dependencies
++ autoconf
+  + Provides: autoreconf
++ automake
+  + Provides: aclocal
++ epm - Pick the lastest install package for your distribution.
+  + Provides: epm, epminstall, mkepmlist
+  + Release: https://moria.whyayh.com/rel/released/software/ThirdParty/epm/
+  + Forked Source: https://github.com/TurtleEngr/epm-deb-pkg
+  + Source: https://github.com/jimjag/epm
+    + Manual: see doc/ dir
+  + Home: https://jimjag.github.io/epm/
++ epm-helper - generates ver files from ver.sh. Cleanup list of file
+  to be packaged.
+  + Provides: mkver.pl, patch-epm-list
+  + Release: https://moria.whyayh.com/rel/released/software/ThirdParty/epm/
+  + Source: https://github.com/TurtleEngr/epm-helper
+
+** Package Steps
++ make config - generate configure script and run it.
++ make build - build the files and install them in dist/usr/local
+  + Manually check epm.list file
++ make test - run the rsnapshot tests
+  + Verify the tests ran OK
++ make package - build the native and portable packages
++ make release - copy package files to a "release" server
++ make dist-clean - remove all generated files
+
+** Files in contrib/epm-pkg/
++ README-pkg.org - this file
++ Makefile - wraps the existing build/install process and adds the
+  steps for packaging
++ epm.patch* - remove dirs that do not belong to the package
++ mx.require - list required packages for the mx distribution
++ ubuntu.require - list required packages for the ubuntu distribution
++ ver.sh* - define the package's meta-data.
+
+*** Generated files
++ configure - created by 'make config' target
++ dist/ - pseudo root. Created by 'make build' and 'make build
+  install' targets
++ pkg/ - put packages here. Created by 'make package' target
+
+*** Generated files in contrib/epm-pkg/
++ ver.mak - used by Makefile
++ ver.epm - used by package target
++ ver.env - used by release target
++ epm.list - list of files in dist/ to be packaged

--- a/contrib/epm-pkg/epm.patch
+++ b/contrib/epm-pkg/epm.patch
@@ -1,0 +1,8 @@
+$pDel{"/usr"} = 1;
+$pDel{"/usr/local"} = 1;
+$pDel{"/usr/local/bin"} = 1;
+$pDel{"/usr/local/etc"} = 1;
+$pDel{"/usr/local/share"} = 1;
+$pDel{"/usr/local/share/doc"} = 1;
+$pDel{"/usr/local/share/man"} = 1;
+$pDel{"/usr/local/share/man/man1"} = 1;

--- a/contrib/epm-pkg/mx.require
+++ b/contrib/epm-pkg/mx.require
@@ -1,0 +1,6 @@
+%provides rsnapshot
+%requires bash
+%requires coreutils
+%requires openssh-client
+%requires perl
+%requires rsync

--- a/contrib/epm-pkg/ubuntu.require
+++ b/contrib/epm-pkg/ubuntu.require
@@ -1,0 +1,6 @@
+%provides rsnapshot
+%requires bash
+%requires coreutils
+%requires openssh-client
+%requires perl
+%requires rsync

--- a/contrib/epm-pkg/ver.sh
+++ b/contrib/epm-pkg/ver.sh
@@ -31,7 +31,7 @@ export ProdRC=""
 # If set and RELEASE=1
   # %release rc.ProdRC
 
-export ProdBuild="1"
+export ProdBuild="2"
 # [0-9.]*
 # Required
 # If RELEASE=1, and ProdRC=""

--- a/contrib/epm-pkg/ver.sh
+++ b/contrib/epm-pkg/ver.sh
@@ -1,0 +1,162 @@
+# Input DEF file for: mkver.pl.  All variables must have "export "
+# at the beginning.  No spaces around the "=".  And all values
+# enclosed with double quotes.  Variables may include other variables
+# in their values.
+
+# Set this to latest version of mkver.pl (earlier DEF files should
+# still work with newer versions of mkver.pl)
+export MkVer="2.2"
+
+export ProdName="rsnapshot"
+# One word [-a-z0-9]
+# Required
+# %provides ProdName
+
+export ProdAlias="rsnapshot"
+# One word [-a-z0-9]
+
+export ProdVer="1.5.1"
+# [0-9]*.[0-9]*{.[0-9]*}
+# Requires 2 numbers, 3'rd number is optional
+# First, Major changes:
+#        Older projects should work, but they may need to be upgraded.
+#        Newer projects will not work with older versions of git-proj
+# Second, Minor changes, fixes, additions. Things probably won't break
+#        for projects with the same Major version number.
+# Third, Internal refactoring changes, changes in test messages, doc changes
+# %version ProdVer
+
+export ProdRC=""
+# Release Candidate ver. Can be one or two numbers.
+# If set and RELEASE=1
+  # %release rc.ProdRC
+
+export ProdBuild="1"
+# [0-9.]*
+# Required
+# If RELEASE=1, and ProdRC=""
+  # %release test.ProdBuild
+
+# Generated: ProdBuildTime=YYYY.MM.DD.hh.mm
+  # If RELEASE=0, or empty, or unset, then use
+  # current time (UTC): %Y.%m.%d.%H.%M
+    # %release ProdBuildTime
+
+export ProdSummary="rsnapshot is a filesystem snapshot utility based on rsync."
+# All on one line (< 80 char)
+# %product ProdSummary
+
+export ProdDesc="rsnapshot makes it easy to make periodic snapshots of local machines, and remote machines over ssh. The code makes extensive use of hard links whenever possible, to greatly reduce the disk space required."
+# All on one line
+# %description ProdDesc
+
+export ProdVendor="TurtleEngr"
+# Required
+# %vendor ProdVendor
+
+export ProdPackager="$USER"
+# Required
+# %packager ProdPackager
+
+export ProdSupport="turtle.engr\@gmail.com"
+# Appended to %vendor
+
+export ProdCopyright=""
+# Current year if not defined
+# %copyright ProdCopyright
+
+export ProdDate=""
+# 20[0-9][0-9]-[01][0-9]-[0123][0-9]
+# Current date (UTC) if empty
+
+export ProdLicense="dist/usr/local/share/doc/rsnapshot/LICENSE"
+# Required
+# %license ProdLicense
+
+export ProdReadMe="dist/usr/local/share/doc/rsnapshot/README.md"
+# Required
+# %readme ProdReadMe
+
+# Third Party (if any) If repackaging a product, define these:
+export ProdTPVendor="rsnapshot"
+# Appended to
+export ProdTPVer="1.5.1"
+# Appended to
+export ProdTPCopyright="dist/usr/share/doc/rsnapshot/LICENSE"
+# Appended to %copyright
+
+export ProdRelServer="moria.whyayh.com"
+export ProdRelRoot="/rel"
+export ProdRelCategory="software/ThirdParty/$ProdName"
+# Generated: ProdRelDir=$ProdRelRoot/released/$ProdRelCategory
+# Generated: ProdDevDir=$ProdRelRoot/development/$ProdRelCategory
+
+# Generated: ProdTag=tag-ProdVer-ProdBuild
+# (All "." in ProdVer converted to "-")
+
+# Generated: ProdOSDist=mx
+# Generated: ProdOSVer=19
+# Generated: ProdOS=mx19
+# Generated: mx=1
+# Generated: mx19=1
+#       OSDist  OSVer
+# linux
+#       deb
+#       ubuntu  16,18
+#       mx      19,20
+#       rhes
+#       cent
+#       fc
+# cygwin
+#       cygwin
+# mswin32
+#       win     xp
+# solaris
+#       sun
+# darwin
+#       mac
+
+# Generated: ProdArch
+# i386
+# x86_64
+
+# Output file control variables. (Unused types can be removed.)
+# The *File vars can include dir. names
+# The *Header and *Footer defaults are more complete than what is
+# shown here.
+
+export envFile="ver.env"
+export envHeader=""
+export envFooter="export CurLogName=$USER\n"
+
+export epmFile="ver.epm"
+export epmHeader="%include contrib/epm-pkg/$ProdOSDist.require"
+export epmFooter="%include contrib/epm-pkg/epm.list"
+
+export hFile="ver.h"
+export hHeader=""
+export hFooter=""
+
+export javaPackage="DIR.DIR.DIR"
+export javaInterface="ver"
+export javaFile="ver.java"
+export javaHeader=""
+export javaFooter=""
+
+export csNamespace="Supernode"
+export csClass="ver"
+export csFile="ver.cs"
+export csHeader=""
+export csFooter=""
+
+export makFile="ver.mak"
+export makHeader=""
+export makFooter="CurLogName = $USER\n"
+
+export plFile="ver.pl"
+export plHeader=""
+export plFooter=""
+
+export xmlFile="ver.xml"
+export xmlHeader=""
+export xmlFooter=""


### PR DESCRIPTION
This process will use the ESP Package Manager (EPM) application to make native packages. EPM can create many different types of packages, and you only need to learn EPM's way of defining the package contents.

Helper programs make it easy to use the meta-data in various tools (make, bash, epm, etc.)
